### PR TITLE
skip 0 cell counts

### DIFF
--- a/R/chordDiagram.R
+++ b/R/chordDiagram.R
@@ -810,7 +810,8 @@ chordDiagramFromDataFrame = function(df, grid.col = NULL, grid.border = NA, tran
 		}
 	}
 
-	for(k in seq_len(nrow(df))) {
+	for(k in seq_len(nrow(df)))
+          if (df$value[k] == 0) next else {
 		if(setequal(direction.type, c("diffHeight"))) {
 			circos.link(df$rn[k], c(df$x1[k] - abs(df$value[k]), df$x1[k]),
 					df$cn[k], c(df$x2[k] - abs(df$value[k]), df$x2[k]),


### PR DESCRIPTION
I've been seeing some undesirable lines in `chordDiagram` PDFs when viewed on Adobe products (reader, acrobat pro, photoshop, illustrator) and other viewers. They seem to be the outlines of transparent objects when the processed data frame, `df`, contains 0s in the `value` column in  `chordDiagramFromDataFrame`.

I can reproduce this with the following script

```r
library('methods')
library('circlize')

nr <- 4
set.seed(1)
mat <- matrix(replicate(nr * nr, rpois(1, sample(1:100))), 4,
              dimnames = list(letters[1:nr], letters[1:nr]))
mat[lower.tri(mat)] <- 0

#    a  b  c  d
# a 29  3 97 27
# b  0 44 83 23
# c  0  0 17 29
# d  0  0  0 43

tf <- tempfile('circos_', getwd(), '.pdf')
pdf(tf)
chordDiagram(mat)
dev.off()

system(sprintf('%s %s', getOption('pdfviewer'), tf))
```

Which results in 

![](http://i.imgur.com/41qQy8Y.png)

The image on the left being the github version and on the right the one with my small change, both viewed on windows/acrobat 9 pro.

I would be interested to know if there is a simpler solution to avoid those lines which do not appear on "cheaper" pdf viewers, apple's preview or phone applications for instance, but _do_ only seem to appear when using Acrobat or other full-featured viewers.

I didn't do any extensive testing, so I'm also not sure if this will break any tests or have unintended side effects which is why I am wondering about alternative solutions.