### PR TITLE
Added documentation to suppress package startup message

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,6 +14,11 @@ Documentation: http://jokergoo.github.io/circlize_book/book/
 If you use it in published research, please cite:
 Gu, Z. circlize implements and enhances circular visualization 
   in R. Bioinformatics 2014.
+
+This message can be suppressed by with this invocation:
+  suppressPackageStartupMessages(library(circlize))
+
+For Rnotebooks, use the chunk option "include = FALSE" instead.
 ========================================
 ")
     packageStartupMessage(msg)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,7 @@ If you use it in published research, please cite:
 Gu, Z. circlize implements and enhances circular visualization 
   in R. Bioinformatics 2014.
 
-This message can be suppressed by with this invocation:
+This message can be suppressed with this invocation:
   suppressPackageStartupMessages(library(circlize))
 
 For Rnotebooks, use the chunk option "include = FALSE" instead.


### PR DESCRIPTION
Hi Zuguang,

I'm using your circlize package for an atypical application - making dials for old manual machining tools.  I decided to do the work as an Rnotebook, https://rpubs.com/dgabbe/548800.  It's a very handy package made even better w/your book.

While I understand the need and desire for your work to be cited and I appreciate the included citation message, there is an unfriendly aspect to it.

In my Rnotebook, I have a 'library' chunk at the top of my file w/the option `echo = FALSE`. That's usually enough to hide any output.  When I generated the html preview, your citation message is displayed right after the title.  When I created a separate R script to generate some graphics, the console is filled with the citation message as well.

My pull request adds some documentation for how to hide the message.  I think this will make for a nicer user experience.  Please feel free to reword my text.