### PR TITLE
Changed 'http:' to 'https:' for consistency & better security

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,5 @@ generate_genomic_figures/
 ^docs$
 ^pkgdown$
 build_pkg_site.R
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,19 +6,19 @@ Date: 2019-12-06
 Author: Zuguang Gu
 Maintainer: Zuguang Gu <z.gu@dkfz.de>
 Depends: R (>= 3.0.0), graphics
-Imports: GlobalOptions (>= 0.1.0), shape, grDevices, utils, stats, 
+Imports: GlobalOptions (>= 0.1.0), shape, grDevices, utils, stats,
     colorspace, methods, grid
 Suggests: knitr, dendextend (>= 1.0.1), ComplexHeatmap (>= 2.0.0), gridBase,
     png
 VignetteBuilder: knitr
-Description: Circular layout is an efficient way for the visualization of huge 
-    amounts of information. Here this package provides an implementation 
-    of circular layout generation in R as well as an enhancement of available 
-    software. The flexibility of the package is based on the usage of low-level 
-    graphics functions such that self-defined high-level graphics can be easily 
-    implemented by users for specific purposes. Together with the seamless 
-    connection between the powerful computational and visual environment in R, 
-    it gives users more convenience and freedom to design figures for 
+Description: Circular layout is an efficient way for the visualization of huge
+    amounts of information. Here this package provides an implementation
+    of circular layout generation in R as well as an enhancement of available
+    software. The flexibility of the package is based on the usage of low-level
+    graphics functions such that self-defined high-level graphics can be easily
+    implemented by users for specific purposes. Together with the seamless
+    connection between the powerful computational and visual environment in R,
+    it gives users more convenience and freedom to design figures for
     better understanding complex patterns behind multiple dimensional data.
-URL: https://github.com/jokergoo/circlize, http://jokergoo.github.io/circlize_book/book/
+URL: https://github.com/jokergoo/circlize, https://jokergoo.github.io/circlize_book/book/
 License: MIT + file LICENSE

--- a/NEWS
+++ b/NEWS
@@ -97,13 +97,13 @@ Changes in version 0.4.0
   measurement in different coordinates
 * enforce asp = 1 when calling plot.default
 * length of axes ticks are set to 2mm by default
-* in axis, the first axis label is shifted if it is exceed the axis and 
+* in axis, the first axis label is shifted if it is exceed the axis and
   so is for the last axis label.
 * text.vjust accepts strings as "2mm", "-2.1 cm" to represent offsets
 * `circos.segments()`: graphic parameters can be set as vectors
 * add `circos.genomicIdeogram()`, `circos.genomicHeatmap()`, `circos.genomicLabels()`
 * add `circos.nestes()`
-* vignette has been moved to http://jokergoo.github.io/circlize_book/book/index.html
+* vignette has been moved to https://jokergoo.github.io/circlize_book/book/index.html
 * add `set.current.cell()`
 * add `h.ratio` argument in `circos.link()`
 
@@ -111,7 +111,7 @@ Changes in version 0.3.10
 ----------------------------------------------------------------------------
 
 * `chordDiagram()`: fixed a bug when the input matrix is stored as a data frame
-* `rainfallTransform()`: add "left" and "right" modes, and now the row order of 
+* `rainfallTransform()`: add "left" and "right" modes, and now the row order of
    the output data frame is as same as the input one.
 * `circos.genomicInitialize()`: it can only plot axes now.
 * `posTransform.text()`: add `extend` option to control the extension of chromsomes
@@ -170,7 +170,7 @@ Changes in version 0.3.3
 
 * `rainfallTransform()` and `genomicDensity()`: can be applied on the bed-format
   data frame directly.
-* add `col2rgb()` which transforms back to the original value based on the color 
+* add `col2rgb()` which transforms back to the original value based on the color
   mapping function.
 * add `circos.yaxis()`
 
@@ -216,7 +216,7 @@ Changes in version 0.2.4
    specified as a three-column data frame.
 * `chordDiagram`: arrows can be used to identify directions
 * ·circos.link`: arrows can be used to identify directions
-* `chordDiagram`: width of self-links are not duplicated. 
+* `chordDiagram`: width of self-links are not duplicated.
 * `circos.link`: if two roots for a link overlaps, the link is de-generated
   as an area with a quadratic curve and an arc.
 * add `circos.dendrogram` which draw dendrograms (dendrogram can be rendered by
@@ -268,7 +268,7 @@ Changes in version 0.2.0
 * set default transparency to 0.5 in `chordDiagram`
 * `circlize` returns value when track.index == 0
 * fixed a bug when text facing is 'bending', all text are plotted in one cell
-* different colors for each rows can be set to `circos.genomicLines` if 
+* different colors for each rows can be set to `circos.genomicLines` if
   type %in% c("segment", "h")
 * pre-allocate the matrix in `.get_color`
 
@@ -328,7 +328,7 @@ Changes in version 0.0.9
 * add a new function `chordDiagram` which support chord diagram
 * add `facing` argument to replace `direction` in `circos.text`
 * `circos.trackPlotRegion` can be used to update a track without re-setting ylim
-* move demo to http://jokergoo.github.io/circlize
+* move demo to https://jokergoo.github.io/circlize
 * re-implement `colorRamp2`
 
 Changes in version 0.0.8
@@ -351,7 +351,7 @@ Change in version 0.0.6
 * order will not change in `circos.trackPlotRegion` when not specifying `factors`, bug fixed
 * add an example in 'draw relation' vignette
 * add a new vignette focusing on phylogenetic tree
-* support directly downloading cytoBand file from UCSC 
+* support directly downloading cytoBand file from UCSC
 
 Changes in version 0.0.5
 ------------------------------------------------------------------------------

--- a/R/chordDiagram.R
+++ b/R/chordDiagram.R
@@ -52,11 +52,11 @@
 # when the table represents information of directional relations. This function
 # visualize tables in a circular way.
 #
-# This function is flexible and contains some settings that may be a little difficult to understand. 
+# This function is flexible and contains some settings that may be a little difficult to understand.
 # Please refer to vignette for better explanation.
 #
 # == seealso
-# http://jokergoo.github.io/circlize_book/book/the-chorddiagram-function.html
+# https://jokergoo.github.io/circlize_book/book/the-chorddiagram-function.html
 #
 # == value
 # A data frame which contains positions of links, columns are:
@@ -68,10 +68,10 @@
 # -``o2`` order of the link on the "to" sector
 # -``x1`` and position of the link on the "from" sector, the interval for the link on the "from" sector is ``c(x1-abs(value), x1)``
 # -``x2`` and position of the link on the "to" sector, the interval for the link on the "from" sector is ``c(x2-abs(value), x2)``
-# 
+#
 # == examples
 # set.seed(999)
-# mat = matrix(sample(18, 18), 3, 6) 
+# mat = matrix(sample(18, 18), 3, 6)
 # rownames(mat) = paste0("S", 1:3)
 # colnames(mat) = paste0("E", 1:6)
 #
@@ -85,45 +85,45 @@
 # circos.clear()
 #
 chordDiagram = function(
-	x, 
-	grid.col = NULL, 
-	grid.border = NA, 
+	x,
+	grid.col = NULL,
+	grid.border = NA,
 	transparency = 0.5,
-	col = NULL, 
-	row.col = NULL, 
-	column.col = NULL, 
-	order = NULL, 
-	directional = 0, 
+	col = NULL,
+	row.col = NULL,
+	column.col = NULL,
+	order = NULL,
+	directional = 0,
 	xmax = NULL,
-	symmetric = FALSE, 
-	keep.diagonal = FALSE, 
-	direction.type = "diffHeight", 
-	diffHeight = convert_height(2, "mm"), 
-	reduce = 1e-5, 
-	self.link = 2, 
+	symmetric = FALSE,
+	keep.diagonal = FALSE,
+	direction.type = "diffHeight",
+	diffHeight = convert_height(2, "mm"),
+	reduce = 1e-5,
+	self.link = 2,
 	preAllocateTracks = NULL,
-	annotationTrack = c("name", "grid", "axis"), 
+	annotationTrack = c("name", "grid", "axis"),
 	annotationTrackHeight = convert_height(c(3, 2), "mm"),
-	link.border = NA, 
-	link.lwd = par("lwd"), 
-	link.lty = par("lty"), 
-	link.sort = FALSE, 
+	link.border = NA,
+	link.lwd = par("lwd"),
+	link.lty = par("lty"),
+	link.sort = FALSE,
 	link.decreasing = TRUE,
-	link.arr.length = ifelse(link.arr.type == "big.arrow", 0.02, 0.4), 
-	link.arr.width = link.arr.length/2, 
-	link.arr.type = "triangle", 
-	link.arr.lty = par("lty"), 
-	link.arr.lwd = par("lwd"), 
-	link.arr.col = par("col"), 
-	link.largest.ontop = FALSE, 
-	link.visible = TRUE, 
-	link.rank = NULL, 
-	link.overlap = FALSE, 
-	scale = FALSE, 
-	big.gap = 10, 
-	small.gap = 1, 
+	link.arr.length = ifelse(link.arr.type == "big.arrow", 0.02, 0.4),
+	link.arr.width = link.arr.length/2,
+	link.arr.type = "triangle",
+	link.arr.lty = par("lty"),
+	link.arr.lwd = par("lwd"),
+	link.arr.col = par("col"),
+	link.largest.ontop = FALSE,
+	link.visible = TRUE,
+	link.rank = NULL,
+	link.overlap = FALSE,
+	scale = FALSE,
+	big.gap = 10,
+	small.gap = 1,
 	...) {
-		
+
 	if(inherits(x, "table"))  {
 		if(length(dim(x)) == 2) {
 			class(x) = "matrix"
@@ -143,7 +143,7 @@ chordDiagram = function(
 			preAllocateTracks = preAllocateTracks, annotationTrack = annotationTrack, annotationTrackHeight = annotationTrackHeight,
 			link.border = link.border, link.lwd = link.lwd, link.lty = link.lty, link.sort = link.sort, link.decreasing = link.decreasing,
 			link.arr.length = link.arr.length, link.arr.width = link.arr.width, link.arr.type = link.arr.type, link.arr.lty = link.arr.lty,
-			link.arr.lwd = link.arr.lwd, link.arr.col = link.arr.col, link.largest.ontop = link.largest.ontop, 
+			link.arr.lwd = link.arr.lwd, link.arr.col = link.arr.col, link.largest.ontop = link.largest.ontop,
 			link.visible = link.visible, link.rank = link.rank, link.overlap = link.overlap, scale = scale, big.gap = big.gap, small.gap = small.gap, ...)
 	} else {
 		x = validate_data_frame(x)
@@ -157,7 +157,7 @@ chordDiagram = function(
 					preAllocateTracks = preAllocateTracks, annotationTrack = annotationTrack, annotationTrackHeight = annotationTrackHeight,
 					link.border = link.border, link.lwd = link.lwd, link.lty = link.lty, link.sort = link.sort, link.decreasing = link.decreasing,
 					link.arr.length = link.arr.length, link.arr.width = link.arr.width, link.arr.type = link.arr.type, link.arr.lty = link.arr.lty,
-					link.arr.lwd = link.arr.lwd, link.arr.col = link.arr.col, link.largest.ontop = link.largest.ontop, 
+					link.arr.lwd = link.arr.lwd, link.arr.col = link.arr.col, link.largest.ontop = link.largest.ontop,
 					link.visible = link.visible, link.rank = link.rank, link.overlap = link.overlap, scale = scale, big.gap = big.gap, small.gap = small.gap, ...)))
 			} else {
 				chordDiagramFromDataFrame(x, grid.col = grid.col, grid.border = grid.border, transparency = transparency,
@@ -166,7 +166,7 @@ chordDiagram = function(
 					preAllocateTracks = preAllocateTracks, annotationTrack = annotationTrack, annotationTrackHeight = annotationTrackHeight,
 					link.border = link.border, link.lwd = link.lwd, link.lty = link.lty, link.sort = link.sort, link.decreasing = link.decreasing,
 					link.arr.length = link.arr.length, link.arr.width = link.arr.width, link.arr.type = link.arr.type, link.arr.lty = link.arr.lty,
-					link.arr.lwd = link.arr.lwd, link.arr.col = link.arr.col, link.largest.ontop = link.largest.ontop, 
+					link.arr.lwd = link.arr.lwd, link.arr.col = link.arr.col, link.largest.ontop = link.largest.ontop,
 					link.visible = link.visible, link.rank = link.rank, link.overlap = link.overlap, scale = scale, big.gap = big.gap, small.gap = small.gap, ...)
 			}
 		} else {
@@ -176,10 +176,10 @@ chordDiagram = function(
 				preAllocateTracks = preAllocateTracks, annotationTrack = annotationTrack, annotationTrackHeight = annotationTrackHeight,
 				link.border = link.border, link.lwd = link.lwd, link.lty = link.lty, link.sort = link.sort, link.decreasing = link.decreasing,
 				link.arr.length = link.arr.length, link.arr.width = link.arr.width, link.arr.type = link.arr.type, link.arr.lty = link.arr.lty,
-				link.arr.lwd = link.arr.lwd, link.arr.col = link.arr.col, link.largest.ontop = link.largest.ontop, 
+				link.arr.lwd = link.arr.lwd, link.arr.col = link.arr.col, link.largest.ontop = link.largest.ontop,
 				link.visible = link.visible, link.rank = link.rank, link.overlap = link.overlap, scale = scale, big.gap = big.gap, small.gap = small.gap, ...)
 		}
-	}	
+	}
 }
 
 # returns a list, each list containing settings for each new track
@@ -284,13 +284,13 @@ mat2df = function(mat) {
 # == param
 # -mat A table which represents as a numeric matrix.
 # -grid.col Grid colors which correspond to matrix rows/columns (or sectors). The length of the vector should be either 1 or ``length(union(rownames(mat), colnames(mat)))``.
-#           It's preferred that ``grid.col`` is a named vector of which names correspond to sectors. 
+#           It's preferred that ``grid.col`` is a named vector of which names correspond to sectors.
 #           If it is not a named vector, the order of ``grid.col`` corresponds to order of sectors.
 # -grid.border border for grids. If it is ``NULL``, the border color is same as grid color
 # -transparency Transparency of link colors, 0 means no transparency and 1 means full transparency.
 #               If transparency is already set in ``col`` or ``row.col`` or ``column.col``, this argument will be ignored.
 #               ``NA``also ignores this argument.
-# -col Colors for links. It can be a matrix which corresponds to ``mat``, or a function which generate colors 
+# -col Colors for links. It can be a matrix which corresponds to ``mat``, or a function which generate colors
 #      according to values in ``mat``, or a single value which means colors for all links are the same, or a three-column
 #      data frame in which the first two columns correspond to row names and columns and the third column is colors. You
 #      may use `colorRamp2` to generate a function which maps values to colors.
@@ -336,7 +336,7 @@ mat2df = function(mat) {
 # -link.arr.lwd line width ofthe single line link which is put in the center of the belt. The format of this argument is same as ``link.lwd``.
 # -link.arr.lty line type of the single line link which is put in the center of the belt. The format of this argument is same as ``link.lwd``.
 # -link.largest.ontop controls the order of adding links, whether based on the absolute value?
-# -link.visible whether plot the link. The value is logical, if it is set to ``FALSE``, the corresponding link will not 
+# -link.visible whether plot the link. The value is logical, if it is set to ``FALSE``, the corresponding link will not
 #            plotted, but the space is still ocuppied. The format of this argument is same as ``link.lwd``
 # -link.rank order to add links to the circle, a large value means to add it later.
 # -link.overlap if it is a directional Chord Diagram, whether the links that come or end in a same sector overlap?
@@ -352,48 +352,48 @@ mat2df = function(mat) {
 # A data frame which contains positions of links, see explanation in `chordDiagram`.
 #
 # == seealso
-# http://jokergoo.github.io/circlize_book/book/the-chorddiagram-function.html
+# https://jokergoo.github.io/circlize_book/book/the-chorddiagram-function.html
 #
 chordDiagramFromMatrix = function(
-	mat, 
-	grid.col = NULL, 
-	grid.border = NA, 
+	mat,
+	grid.col = NULL,
+	grid.border = NA,
 	transparency = 0.5,
-	col = NULL, 
-	row.col = NULL, 
-	column.col = NULL, 
-	order = NULL, 
+	col = NULL,
+	row.col = NULL,
+	column.col = NULL,
+	order = NULL,
 	directional = 0,
-	direction.type = "diffHeight", 
-	diffHeight = convert_height(2, "mm"), 
-	reduce = 1e-5, 
-	xmax = NULL, 
+	direction.type = "diffHeight",
+	diffHeight = convert_height(2, "mm"),
+	reduce = 1e-5,
+	xmax = NULL,
 	self.link = 2,
-	symmetric = FALSE, 
-	keep.diagonal = FALSE, 
+	symmetric = FALSE,
+	keep.diagonal = FALSE,
 	preAllocateTracks = NULL,
-	annotationTrack = c("name", "grid", "axis"), 
+	annotationTrack = c("name", "grid", "axis"),
 	annotationTrackHeight = convert_height(c(3, 2), "mm"),
-	link.border = NA, 
-	link.lwd = par("lwd"), 
-	link.lty = par("lty"), 
-	link.sort = FALSE, 
+	link.border = NA,
+	link.lwd = par("lwd"),
+	link.lty = par("lty"),
+	link.sort = FALSE,
 	link.decreasing = TRUE,
-	link.arr.length = ifelse(link.arr.type == "big.arrow", 0.02, 0.4), 
-	link.arr.width = link.arr.length/2, 
-	link.arr.type = "triangle", 
-	link.arr.lty = par("lty"), 
-	link.arr.lwd = par("lwd"), 
-	link.arr.col = par("col"), 
-	link.largest.ontop = FALSE, 
-	link.visible = TRUE, 
-	link.rank = NULL, 
+	link.arr.length = ifelse(link.arr.type == "big.arrow", 0.02, 0.4),
+	link.arr.width = link.arr.length/2,
+	link.arr.type = "triangle",
+	link.arr.lty = par("lty"),
+	link.arr.lwd = par("lwd"),
+	link.arr.col = par("col"),
+	link.largest.ontop = FALSE,
+	link.visible = TRUE,
+	link.rank = NULL,
 	link.overlap = FALSE,
-	scale = FALSE, 
-	big.gap = 10, 
-	small.gap = 1, 
+	scale = FALSE,
+	big.gap = 10,
+	small.gap = 1,
 	...) {
-	
+
 	if(!is.matrix(mat)) {
 		stop_wrap("`mat` can only be a matrix.")
 	}
@@ -434,7 +434,7 @@ chordDiagramFromMatrix = function(
 		}
 
 		mat[upper.tri(mat, diag = !keep.diagonal)] = 0
-		
+
 	}
 
 	mat[is.na(mat)] = 0
@@ -447,14 +447,14 @@ chordDiagramFromMatrix = function(
 			stop_wrap("Elements in `order` should be same as in `union(rownames(mat), colnames(mat))`.")
 		}
 	}
-	
+
 	if(is.null(rownames(mat))) {
 		rownames(mat) = paste0("R", seq_len(nrow(mat)))
 	}
 	if(is.null(colnames(mat))) {
 		colnames(mat) = paste0("C", seq_len(ncol(mat)))
 	}
-	
+
 
 	# width of the category is almost 0, it means this category has no link to the others
 	rs = rowSums(abs(mat))
@@ -490,22 +490,22 @@ chordDiagramFromMatrix = function(
 
 	# if the matrix is reduced
 	if(sum(length(ri) + length(ci)) < sum(ncol(mat) + nrow(mat))) {
-		
+
 		un = union(rownames(mat), colnames(mat))
 		nn = union(rownames(mat)[ri], colnames(mat)[ci])
 		if(length(circos.par("gap.degree")) == length(un)) {
 			old.gap.degree = circos.par("gap.degree")
 			circos.par("gap.degree" = old.gap.degree[un %in% nn])
 		}
-		
+
 		if(!is.null(grid.col)) {
 			if(is.null(names(grid.col)) && length(grid.col) == length(un)) {
 				grid.col = grid.col[un %in% nn]
 			}
 		}
-		
+
 	}
-	
+
 	mat = mat[ri, ci, drop = FALSE]
 	if(is.matrix(col)) {
 		col = col[ri, ci, drop = FALSE]
@@ -524,7 +524,7 @@ chordDiagramFromMatrix = function(
 	nn = union(names(rs), names(cs))
 	xlim = numeric(length(nn))
 	names(xlim) = nn
-	
+
 	if(!is.null(order)) {
 		xlim = xlim[order]
 	}
@@ -620,15 +620,15 @@ chordDiagramFromMatrix = function(
 	chordDiagramFromDataFrame(df[c(1, 2, 5)], grid.col = grid.col, grid.border = grid.border, transparency = NA,
 		col = psubset(col, df$ri, df$ci), order = order, xmax = xmax,
 		directional = psubset(directional, df$ri, df$ci),
-		direction.type = psubset(direction.type, df$ri, df$ci), 
-		diffHeight = diffHeight, 
+		direction.type = psubset(direction.type, df$ri, df$ci),
+		diffHeight = diffHeight,
 		reduce = 0, self.link = self.link,
 		preAllocateTracks = preAllocateTracks,
 		annotationTrack = annotationTrack, annotationTrackHeight = annotationTrackHeight,
 		link.sort = link.sort, link.decreasing = link.decreasing,
-		link.border = psubset(link.border, df$ri, df$ci), 
+		link.border = psubset(link.border, df$ri, df$ci),
 		link.lwd = psubset(link.lwd, df$ri, df$ci),
-		link.lty = psubset(link.lty, df$ri, df$ci), 
+		link.lty = psubset(link.lty, df$ri, df$ci),
 		link.arr.length = psubset(link.arr.length, df$ri, df$ci),
 		link.arr.width = psubset(link.arr.width, df$ri, df$ci),
 		link.arr.type = psubset(link.arr.type, df$ri, df$ci),
@@ -643,7 +643,7 @@ chordDiagramFromMatrix = function(
 		big.gap = big.gap,
 		small.gap = small.gap,
 		...)
-	
+
 }
 
 
@@ -655,13 +655,13 @@ chordDiagramFromMatrix = function(
 #     contains numeric values which are mapped to the width of links as well as the colors if ``col`` is specified as a color mapping function.
 #     The sectors in the plot will be ``union(df[[1]], df[[2]])``.
 # -grid.col Grid colors which correspond to sectors. The length of the vector should be either 1 or the number of sectors.
-#           It's preferred that ``grid.col`` is a named vector of which names correspond to sectors. 
+#           It's preferred that ``grid.col`` is a named vector of which names correspond to sectors.
 #           If it is not a named vector, the order of ``grid.col`` corresponds to order of sectors.
 # -grid.border border for grids. If it is ``NULL``, the border color is same as grid color
 # -transparency Transparency of link colors, 0 means no transparency and 1 means full transparency.
 #               If transparency is already set in ``col`` or ``row.col`` or ``column.col``, this argument will be ignored.
 #               ``NA``also ignores this argument.
-# -col Colors for links. It can be a vector which corresponds to connections in ``df``, or a function which generate colors 
+# -col Colors for links. It can be a vector which corresponds to connections in ``df``, or a function which generate colors
 #      according to values (the third column) in ``df``, or a single value which means colors for all links are the same. You
 #      may use `colorRamp2` to generate a function which maps values to colors.
 # -order Order of sectors. Default order is ``union(df[[1]], df[[2]])``.
@@ -670,7 +670,7 @@ chordDiagramFromMatrix = function(
 # -xmax maximum value on x-axes, the value should be a named vector.
 # -direction.type type for representing directions. Can be one or two values in "diffHeight" and "arrows". If the value contains "diffHeight",
 #            different heights of the links are used to represent the directions for which starting root has long height to give people feeling
-#            that something is comming out. If the value contains "arrows", users can customize arrows with following arguments. 
+#            that something is comming out. If the value contains "arrows", users can customize arrows with following arguments.
 #             The value can be a vector which has same length as number of rows in ``df``. Note if you want to set both ``diffHeight``
 #             and ``arrows`` for certain links, you need to embed these two options into one string such as ``"diffHeight+arrows"``.
 # -diffHeight The difference of height between two 'roots' if ``directional`` is set to ``TRUE``. If the value is set to
@@ -699,7 +699,7 @@ chordDiagramFromMatrix = function(
 # -link.arr.lwd line width ofthe single line link which is put in the center of the belt. The format of this argument is same as ``link.lwd``.
 # -link.arr.lty line type of the single line link which is put in the center of the belt. The format of this argument is same as ``link.lwd``.
 # -link.largest.ontop controls the order of adding links, whether based on the absolute value?
-# -link.visible whether plot the link. The value is logical, if it is set to ``FALSE``, the corresponding link will not 
+# -link.visible whether plot the link. The value is logical, if it is set to ``FALSE``, the corresponding link will not
 #            plotted, but the space is still ocuppied. The format of this argument is same as ``link.lwd``
 # -link.rank order to add links to the circle, a large value means to add it later.
 # -link.overlap if it is a directional Chord Diagram, whether the links that come or end in a same sector overlap?
@@ -715,41 +715,41 @@ chordDiagramFromMatrix = function(
 # A data frame which contains positions of links, see explanation in `chordDiagram`.
 #
 # == seealso
-# http://jokergoo.github.io/circlize_book/book/the-chorddiagram-function.html
+# https://jokergoo.github.io/circlize_book/book/the-chorddiagram-function.html
 #
 chordDiagramFromDataFrame = function(
-	df, 
-	grid.col = NULL, 
-	grid.border = NA, 
+	df,
+	grid.col = NULL,
+	grid.border = NA,
 	transparency = 0.5,
-	col = NULL, 
-	order = NULL, 
-	directional = 0, 
+	col = NULL,
+	order = NULL,
+	directional = 0,
 	xmax = NULL,
-	direction.type = "diffHeight", 
-	diffHeight = convert_height(2, "mm"), 
-	reduce = 1e-5, 
-	self.link = 2, 
+	direction.type = "diffHeight",
+	diffHeight = convert_height(2, "mm"),
+	reduce = 1e-5,
+	self.link = 2,
 	preAllocateTracks = NULL,
-	annotationTrack = c("name", "grid", "axis"), 
+	annotationTrack = c("name", "grid", "axis"),
 	annotationTrackHeight = convert_height(c(3, 2), "mm"),
-	link.border = NA, 
-	link.lwd = par("lwd"), 
-	link.lty = par("lty"), 
-	link.sort = FALSE, 
+	link.border = NA,
+	link.lwd = par("lwd"),
+	link.lty = par("lty"),
+	link.sort = FALSE,
 	link.decreasing = TRUE,
-	link.arr.length = ifelse(link.arr.type == "big.arrow", 0.02, 0.4), 
-	link.arr.width = link.arr.length/2, 
-	link.arr.type = "triangle", 
-	link.arr.lty = par("lty"), 
-	link.arr.lwd = par("lwd"), 
-	link.arr.col = par("col"), 
-	link.largest.ontop = FALSE, 
-	link.visible = TRUE, 
-	link.rank = seq_len(nrow(df)), 
+	link.arr.length = ifelse(link.arr.type == "big.arrow", 0.02, 0.4),
+	link.arr.width = link.arr.length/2,
+	link.arr.type = "triangle",
+	link.arr.lty = par("lty"),
+	link.arr.lwd = par("lwd"),
+	link.arr.col = par("col"),
+	link.largest.ontop = FALSE,
+	link.visible = TRUE,
+	link.rank = seq_len(nrow(df)),
 	link.overlap = FALSE,
-	scale = FALSE, 
-	big.gap = 10, 
+	scale = FALSE,
+	big.gap = 10,
 	small.gap = 1,
 	...) {
 
@@ -804,7 +804,7 @@ chordDiagramFromDataFrame = function(
 			cate = cate[order]
 		} else {
 			if(!setequal(order, cate)) {
-				stop_wrap("`order` should only be picked from sectors.")	
+				stop_wrap("`order` should only be picked from sectors.")
 			}
 			cate = order
 		}
@@ -841,7 +841,7 @@ chordDiagramFromDataFrame = function(
 		} else {
 			col = rep(col, nr)[1:nr]
 		}
-	} 
+	}
 
 	rgb_mat = t(col2rgb(col, alpha = TRUE))
 	if(length(transparency) == nrow(rgb_mat)) {
@@ -917,7 +917,7 @@ chordDiagramFromDataFrame = function(
 		col = col[l]
 		link.border = link.border[l]
 		link.lwd = link.lwd[l]
-		link.lty = link.lty[l] 
+		link.lty = link.lty[l]
 		link.arr.length = link.arr.length[l]
 		link.arr.width = link.arr.width[l]
 		link.arr.type = link.arr.type[l]
@@ -980,7 +980,7 @@ chordDiagramFromDataFrame = function(
 			df$o1[l] = od[[nm]] # adjust rows according to the order in current sector
 			df$x1[l][od[[nm]]] = cumsum(abs(df$value1[l])[od[[nm]]]) # position
 
-			l2 = df$rn == nm & df$cn == nm 
+			l2 = df$rn == nm & df$cn == nm
 			if(sum(l2)) { # there is a self link
 				if(self.link == 1) {
 					df$x2[l2] = df$x1[l2]+abs(df$value1[l2])*0.000001
@@ -1089,7 +1089,7 @@ chordDiagramFromDataFrame = function(
 			} else {
 				start_degree = circos.par$start.degree + (180 - d1)/2
 			}
-			suppressWarnings(circos.par(start.degree = start_degree, 
+			suppressWarnings(circos.par(start.degree = start_degree,
 				gap.after = c(rep(small.gap, n_df1 - 1), big.gap, rep(small.gap, n_df2 - 1), big.gap)))
 		} else {
 			# warning("The two sets of sectors overlap, ignore `gap.degree`.")
@@ -1120,7 +1120,7 @@ chordDiagramFromDataFrame = function(
 			}, track.height = annotationTrackHeight[which(annotationTrack %in% "name")])
     }
 	if("grid" %in% annotationTrack) {
-		circos.trackPlotRegion(ylim = c(0, 1), bg.border = NA, 
+		circos.trackPlotRegion(ylim = c(0, 1), bg.border = NA,
 			panel.fun = function(x, y) {
 				xlim = get.cell.meta.data("xlim")
 				current.sector.index = get.cell.meta.data("sector.index")
@@ -1135,7 +1135,7 @@ chordDiagramFromDataFrame = function(
 				}
 			}, track.height = annotationTrackHeight[which(annotationTrack %in% "grid")])
 	}
-    
+
     rou = get_most_inside_radius()
     rou1 = numeric(nr)
     rou2 = numeric(nr)
@@ -1189,15 +1189,15 @@ chordDiagramFromDataFrame = function(
 			if(setequal(direction.type, c("diffHeight"))) {
 				circos.link(df$rn[k], c(df$x1[k] - abs(df$value1[k]), df$x1[k]),
 						df$cn[k], c(df$x2[k] - abs(df$value2[k]), df$x2[k]),
-						directional = 0, col = col[k], rou1 = rou1[k], rou2 = rou2[k], 
+						directional = 0, col = col[k], rou1 = rou1[k], rou2 = rou2[k],
 						border = link.border[k], lwd = link.lwd[k], lty = link.lty[k],
-						...)	
+						...)
 			} else if(grepl("arrows", direction.type[k])) {
 				circos.link(df$rn[k], c(df$x1[k] - abs(df$value1[k]), df$x1[k]),
 							df$cn[k], c(df$x2[k] - abs(df$value2[k]), df$x2[k]),
-							directional = directional[k], col = col[k], rou1 = rou1[k], rou2 = rou2[k], 
-							border = link.border[k], 
-							lwd = link.lwd[k], lty = link.lty[k], 
+							directional = directional[k], col = col[k], rou1 = rou1[k], rou2 = rou2[k],
+							border = link.border[k],
+							lwd = link.lwd[k], lty = link.lty[k],
 							arr.length = link.arr.length[k], arr.width = link.arr.width[k],
 							arr.type = link.arr.type[k], arr.col = link.arr.col[k],
 							arr.lty = link.arr.lty[k], arr.lwd = link.arr.lwd[k],
@@ -1205,7 +1205,7 @@ chordDiagramFromDataFrame = function(
 			}
 		}
     }
-	
+
 	df$col = col
 
 	suppressWarnings(circos.par("cell.padding" = o.cell.padding, "start.degree" = o.start.degree,
@@ -1250,7 +1250,7 @@ calc_gap = function(x1, x2, big.gap = 10, small.gap = 1) {
 		n2 = length(unique(x1[, 2]))
 	}
 	sum_gap1 = sum(c(rep(small.gap, n1 - 1), big.gap, rep(small.gap, n2 - 1), big.gap))
-		
+
 	if(is.matrix(x2)) {
 		sum2 = sum(abs(x2))
 		n1 = nrow(x2)

--- a/R/circos.nested.R
+++ b/R/circos.nested.R
@@ -29,19 +29,19 @@
 # either.
 #
 # == seealso
-# http://jokergoo.github.io/circlize_book/book/nested-zooming.html
+# https://jokergoo.github.io/circlize_book/book/nested-zooming.html
 #
 # == author
 # Zuguang Gu <z.gu@dkfz.de>
 #
 circos.nested = function(
-	f1, 
-	f2, 
-	correspondance, 
+	f1,
+	f2,
+	correspondance,
 	connection_height = convert_height(5, "mm"),
-	connection_col = NA, 
+	connection_col = NA,
 	connection_border = "black",
-	connection_lty = par("lty"), 
+	connection_lty = par("lty"),
 	connection_lwd = par("lwd"),
 	adjust_start_degree = TRUE) {
 
@@ -98,7 +98,7 @@ circos.nested = function(
 	}
 
 	# in correspondace, positions are already sorted by the 4,5,6 columns
-	# here we test for a sector in f1(), 
+	# here we test for a sector in f1(),
 	# if(any(tapply(correspondance[, 2], correspondance[, 1], is.unsorted))) {
 	# 	warning(strwrap2("Sectors in `f2()` which belongs to one single sector in `f1()` should be sorted by positions, or else connection lines may overlap."))
 	# }
@@ -169,7 +169,7 @@ circos.nested = function(
 		col, border, lty, lwd) {
 		cell.top.radius = get.cell.meta.data("cell.top.radius")
 		cell.bottom.radius = get.cell.meta.data("cell.bottom.radius")
-		df = reverse.circlize(c(c1_theta1, c1_theta2, c2_theta1, c2_theta2), 
+		df = reverse.circlize(c(c1_theta1, c1_theta2, c2_theta1, c2_theta2),
 			c(cell.top.radius, cell.top.radius, cell.bottom.radius, cell.bottom.radius))
 
 	    x21 = df[1, 1]
@@ -199,32 +199,32 @@ circos.nested = function(
 		connection_lwd = rep(connection_lwd, nr)
 	}
 
-	# make the connections 
+	# make the connections
 	circos.track(ylim = c(0, 1), track.height = connection_height, panel.fun = function(x, y) {
 
 	    l = correspondance[[1]] == CELL_META$sector.index
 	    if(sum(l) == 0) {
 	    	return(NULL)
 	    }
-	    
+
 	    for(i in which(l)) {
 	    	make_connection(correspondance[i, 1], correspondance[i, "c1_theta1"], correspondance[i, "c1_theta2"],
 	    		correspondance[i, "c2_theta1"], correspondance[i, "c2_theta2"],
 	    		connection_col[i], connection_border[i], connection_lty[i], connection_lwd[i])
 	    }
-	    
+
 	}, track.margin = c(0, 0), cell.padding = c(0, 0, 0, 0), bg.border = NA)
 
 	circos.clear()
 
 	op = par("new")
 	par(new = TRUE)
-	
+
 	if(adjust_start_degree) {
 		circos.par(start.degree = offset)
 	}
 
-	circos.par(canvas.xlim = c(-param1$canvas.xlim[2]/r2, param1$canvas.xlim[2]/r2), 
+	circos.par(canvas.xlim = c(-param1$canvas.xlim[2]/r2, param1$canvas.xlim[2]/r2),
 		       canvas.ylim = c(-param1$canvas.xlim[2]/r2, param1$canvas.xlim[2]/r2))
 	f2()
 	circos.clear()

--- a/R/genomic_utils.R
+++ b/R/genomic_utils.R
@@ -11,10 +11,10 @@
 #           If ``chromosome.index`` is set, this argument is enforced to ``FALSE``
 #
 # == details
-# The function read the cytoband data, sort the chromosome names and calculate the length of each chromosome. 
+# The function read the cytoband data, sort the chromosome names and calculate the length of each chromosome.
 # By default, it is human hg19 cytoband data.
 #
-# You can find the data structure of the cytoband data from http://hgdownload.cse.ucsc.edu/goldenpath/hg19/database/cytoBand.txt.gz
+# You can find the data structure of the cytoband data from https://hgdownload.cse.ucsc.edu/goldenpath/hg19/database/cytoBand.txt.gz
 #
 # == values
 # -``df``         Data frame for cytoband data (rows are sorted if ``sort.chr`` is set to ``TRUE``)
@@ -24,21 +24,21 @@
 # == example
 # data = read.cytoband(species = "hg19")
 # data = read.cytoband(cytoband = system.file(package = "circlize", "extdata", "cytoBand.txt"))
-# cytoband = read.table(system.file(package = "circlize", "extdata", "cytoBand.txt"), 
+# cytoband = read.table(system.file(package = "circlize", "extdata", "cytoBand.txt"),
 #     colClasses = c("character", "numeric", "numeric", "character", "character"), sep = "\t")
 # data = read.cytoband(cytoband = cytoband)
 read.cytoband = function(
-	cytoband = system.file(package = "circlize", "extdata", "cytoBand.txt"), 
-	species = NULL, 
-    chromosome.index = usable_chromosomes(species), 
+	cytoband = system.file(package = "circlize", "extdata", "cytoBand.txt"),
+	species = NULL,
+    chromosome.index = usable_chromosomes(species),
     sort.chr = TRUE) {
 
 	# this function should also take charge of the order of chromosome
 	if(!is.null(chromosome.index)) sort.chr = FALSE
-	
+
 	# `species` is prior to `cytoband`
 	if(!is.null(species)) {
-		url = paste("http://hgdownload.cse.ucsc.edu/goldenPath/", species, "/database/cytoBand.txt.gz", sep = "")
+		url = paste("https://hgdownload.cse.ucsc.edu/goldenPath/", species, "/database/cytoBand.txt.gz", sep = "")
 		cytoband = paste0(circos.par("__tempdir__"), "/", species, "_cytoBand.txt.gz")
 		if(!file.exists(cytoband)) {
 			e = try(suppressWarnings(download.file(url, destfile = cytoband, quiet = TRUE)), silent = TRUE)
@@ -53,14 +53,14 @@ read.cytoband = function(
 			}
 		}
 	}
-	
+
 	if(is.data.frame(cytoband)) {
 		d = cytoband
 	} else {
 		if(grepl("\\.gz$", cytoband)) {
 			cytoband = gzfile(cytoband)
 		}
-		
+
 		d = read.table(cytoband, colClasses = c("character", "numeric", "numeric", "character", "character"), sep = "\t", stringsAsFactors = FALSE)
 	}
 
@@ -77,7 +77,7 @@ read.cytoband = function(
 	if(nrow(d) == 0) {
 		stop_wrap("Cannot find any chromosome. It is probably related to your chromosome names having or not having 'chr' prefix.")
 	}
-	
+
 	if(is.null(chromosome.index)) {
 		if(is.factor(d[[1]])) {
 			chromosome = levels(d[[1]])
@@ -100,7 +100,7 @@ read.cytoband = function(
 		dnew = rbind(dnew, d2)
 	}
 	names(chr.len) = chromosome
-	
+
 	return(list(df = dnew, chromosome = chromosome, chr.len = chr.len))
 }
 
@@ -117,10 +117,10 @@ read.cytoband = function(
 #           If ``chromosome.index`` is set, this argument is enforced to ``FALSE``
 #
 # == details
-# The function read the chromInfo data, sort the chromosome names and calculate the length of each chromosome. 
+# The function read the chromInfo data, sort the chromosome names and calculate the length of each chromosome.
 # By default, it is human hg19 chromInfo data.
 #
-# You can find the data structure for the chromInfo data from http://hgdownload.cse.ucsc.edu/goldenpath/hg19/database/chromInfo.txt.gz
+# You can find the data structure for the chromInfo data from https://hgdownload.cse.ucsc.edu/goldenpath/hg19/database/chromInfo.txt.gz
 #
 # == values
 # -``df``         Data frame for chromInfo data (rows are sorted if ``sort.chr`` is set to ``TRUE``)
@@ -130,20 +130,20 @@ read.cytoband = function(
 # == example
 # data = read.chromInfo(species = "hg19")
 # data = read.chromInfo(chromInfo = system.file(package = "circlize", "extdata", "chromInfo.txt"))
-# chromInfo = read.table(system.file(package = "circlize", "extdata", "chromInfo.txt"), 
+# chromInfo = read.table(system.file(package = "circlize", "extdata", "chromInfo.txt"),
 #     colClasses = c("character", "numeric"), sep = "\t")
 # data = read.chromInfo(chromInfo = chromInfo)
 read.chromInfo = function(
-	chromInfo = system.file(package = "circlize", "extdata", "chromInfo.txt"), 
-	species = NULL, 
-    chromosome.index = usable_chromosomes(species), 
+	chromInfo = system.file(package = "circlize", "extdata", "chromInfo.txt"),
+	species = NULL,
+    chromosome.index = usable_chromosomes(species),
     sort.chr = TRUE) {
-	
+
 	# this function should also take charge of the order of chromosome
 	if(!is.null(chromosome.index)) sort.chr = FALSE
-	
+
 	if(!is.null(species)) {
-		url = paste("http://hgdownload.cse.ucsc.edu/goldenPath/", species, "/database/chromInfo.txt.gz", sep = "")
+		url = paste("https://hgdownload.cse.ucsc.edu/goldenPath/", species, "/database/chromInfo.txt.gz", sep = "")
 		chromInfo = paste0(circos.par("__tempdir__"), "/", species, "_chromInfo.txt.gz")
 		if(!file.exists(chromInfo)) {
 			e = try(suppressWarnings(download.file(url, destfile = chromInfo, quiet = TRUE)), silent = TRUE)
@@ -158,14 +158,14 @@ read.chromInfo = function(
 			}
 		}
 	}
-	
+
 	if(is.data.frame(chromInfo)) {
 		d = chromInfo
 	} else {
 		if(grepl("\\.gz$", chromInfo)) {
 			chromInfo = gzfile(chromInfo)
 		}
-		
+
 		d = read.table(chromInfo, colClasses = c("character", "numeric"), sep = "\t", stringsAsFactors = FALSE)[1:2]  # only first two columns
 	}
 	rownames(d) = d[[1]]
@@ -182,7 +182,7 @@ read.chromInfo = function(
 	if(nrow(d) == 0) {
 		stop_wrap("Cannot find any chromosome. It is probably related to your chromosome names having or not having 'chr' prefix.")
 	}
-	
+
 	# now cytoband data is normalized to `d`
 	if(!is.null(chromosome.index)) {
 		chromosome.index = intersect(chromosome.index, unique(as.vector(d[[1]])))
@@ -212,7 +212,7 @@ read.chromInfo = function(
 	names(chr.len) = chromosome
 
 	dnew = data.frame(chr = chromosome, start = rep(0, nrow(dnew)), end = dnew[[2]], stringsAsFactors = FALSE)
-	
+
 	return(list(df = dnew, chromosome = chromosome, chr.len = chr.len))
 }
 
@@ -238,10 +238,10 @@ usable_chromosomes = function(species) {
 # -x A vector containing the Giemsa stain results
 #
 # == details
-# The color theme is from http://circos.ca/tutorials/course/slides/session-2.pdf, page 42.
+# The color theme is from https://circos.ca/tutorials/course/slides/session-2.pdf, page 42.
 cytoband.col = function(x) {
 	x = as.vector(x)
-	col.panel = c("gpos100" = rgb(0, 0, 0, maxColorValue = 255), 
+	col.panel = c("gpos100" = rgb(0, 0, 0, maxColorValue = 255),
                   "gpos"    = rgb(0, 0, 0, maxColorValue = 255),
                   "gpos75"  = rgb(130, 130, 130, maxColorValue = 255),
                   "gpos66"  = rgb(160, 160, 160, maxColorValue = 255),
@@ -271,8 +271,8 @@ cytoband.col = function(x) {
 # The function will uniformly sample positions from the genome. Chromosome names start with "chr"
 # and positions are sorted. The final number of rows may not be exactly as same as ``nr``.
 generateRandomBed = function(
-	nr = 10000, 
-	nc = 1, 
+	nr = 10000,
+	nc = 1,
 	fun = function(k) rnorm(k, 0, 0.5),
     species = NULL) {
 	cyto = read.cytoband(species = species)
@@ -296,7 +296,7 @@ generateRandomBed = function(
 	for(i in seq_along(dl)) {
 		df = rbind(df, dl[[i]])
 	}
-	
+
 	if(ncol(df) == 3) {
 		colnames(df) = c("chr", "start", "end")
 	} else {
@@ -308,7 +308,7 @@ generateRandomBed = function(
 
 sort_chr = function(chromosome) {
 	chromosome = sort(chromosome)
-	
+
 	chromosome.ind = gsub("chr", "", chromosome)
 	chromosome.ind = gsub("_.*$", "", chromosome.ind)
 	l_num = grepl("^\\d+$", chromosome.ind)

--- a/R/global.R
+++ b/R/global.R
@@ -21,7 +21,7 @@ resetGlobalVariable()
 # -READ.ONLY please ignore
 # -LOCAL please ignore
 # -ADD please ignore
-# 
+#
 # == details
 # Global parameters for the circular layout. Currently supported parameters are:
 #
@@ -51,7 +51,7 @@ resetGlobalVariable()
 #     `convert_height` can be used to set the height to an absolute unit.
 # -``points.overflow.warning`` Since each cell is in fact not a real plotting region but only
 #     an ordinary rectangle, it does not eliminate points that are plotted out of
-#     the region. So if some points are out of the plotting region, ``circlize`` would continue drawing the points and printing warnings. In some 
+#     the region. So if some points are out of the plotting region, ``circlize`` would continue drawing the points and printing warnings. In some
 #     cases, draw something out of the plotting region is useful, such as draw
 #     some legend or text. Set this value to ``FALSE`` to turn off the warnings.
 # -``canvas.xlim``              The coordinate for the canvas. Because ``circlize`` draws everything (or almost everything) inside the unit circle,
@@ -63,16 +63,16 @@ resetGlobalVariable()
 # -``canvas.ylim``              The coordinate for the canvas. By default it is ``c(-1, 1)``
 # -``clock.wise``               The direction for adding sectors. Default is ``TRUE``.
 #
-# Similar as `graphics::par`, you can get the parameter values by specifying the 
+# Similar as `graphics::par`, you can get the parameter values by specifying the
 # names of parameters and you can set the parameter values by specifying a
 # named list which contains the new values.
 #
-# ``gap.degree``, ``start.degree``, ``canvas.xlim``, ``canvas.ylim`` and ``clock.wise`` 
+# ``gap.degree``, ``start.degree``, ``canvas.xlim``, ``canvas.ylim`` and ``clock.wise``
 # only be set before the initialization of the circular layout
 # (i.e. before calling `circos.initialize`) because these values will not be changed after
 # adding sectors on the circle. The left and right padding for ``cell.padding`` will also be
 # ignored after the initialization because all cells in a sector would share the same
-# left and right paddings. 
+# left and right paddings.
 circos.par = function(..., RESET = FALSE, READ.ONLY = NULL, LOCAL = FALSE, ADD = FALSE) {}
 circos.par = setGlobalOptions(
 	start.degree = list(
@@ -186,7 +186,7 @@ is.circos.initialized = function() {
 # -xlim    Ranges for values on x-axes, see "details" section for explanation of the format
 # -sector.width Width for each sector. The length of the vector should be either 1 which means
 #          all sectors have same width or as same as the number of sectors. Values for
-#          the vector are relative, and they will be scaled by dividing their summation. 
+#          the vector are relative, and they will be scaled by dividing their summation.
 #          By default, it is ``NULL`` which means the width of sectors correspond to the data
 #          range in sectors.
 #
@@ -215,26 +215,26 @@ is.circos.initialized = function() {
 # The function finally calls `graphics::plot` with enforing aspect ratio to be 1 and be ready for adding graphics.
 #
 # == seealso
-# http://jokergoo.github.io/circlize_book/book/circular-layout.html
+# https://jokergoo.github.io/circlize_book/book/circular-layout.html
 circos.initialize = function(
-	factors, 
-	x = NULL, 
-	xlim = NULL, 
+	factors,
+	x = NULL,
+	xlim = NULL,
 	sector.width = NULL) {
 
     resetGlobalVariable()
-	
+
 	.SECTOR.DATA = get(".SECTOR.DATA", envir = .CIRCOS.ENV)
 	.CELL.DATA = get(".CELL.DATA", envir = .CIRCOS.ENV)
 
 	if(is.numeric(factor)) {
 		warning_wrap("Your `factor` is numeric, it will be converted to characters internally.")
 	}
-	
+
 	if(any(factors == "")) {
 		stop_wrap("`factors` cannot contain empty strings.")
 	}
-	
+
     if(! is.factor(factors)) {
         if(length(factors) == length(unique(factors))) {
            factors = factor(factors, levels = factors)
@@ -248,7 +248,7 @@ circos.initialize = function(
     if(!is.null(x)) {
     	x = as.numeric(x)
     }
-    
+
     # initialize .SECTOR.DATA
     # you can think it as the global x axis configuration
     # calculate min and max value for each sectors
@@ -257,10 +257,10 @@ circos.initialize = function(
     if(is.vector(xlim)) {
         if(length(xlim) != 2) {
             stop_wrap("Since `xlim` is vector, it should have length of 2.")
-        }    
+        }
 
         xlim = as.numeric(xlim)
-        
+
         min.value = rep(xlim[1], length(le))
         max.value = rep(xlim[2], length(le))
     } else if(is.matrix(xlim) || is.data.frame(xlim)) {
@@ -278,11 +278,11 @@ circos.initialize = function(
     	dim(xlim2) = dim(xlim)
     	dimnames(xlim2) = dimnames(xlim)
     	xlim = xlim2
-        
+
         min.value = apply(xlim, 1, function(x) x[1])
         max.value = apply(xlim, 1, function(x) x[2])
     } else if(is.vector(x)) {
-    
+
         if(length(x) != length(factors)) {
             stop_wrap("Length of `x` and length of `factors` differ.")
         }
@@ -291,54 +291,54 @@ circos.initialize = function(
     } else {
 		stop_wrap("You should specify either `x` or `xlim`.")
 	}
-    
+
     cell.padding = circos.par("cell.padding")
-    
+
 	# range for sectors
     sector.range = max.value - min.value
     n.sector = length(le)
-    
+
     sector = vector("list", 7)
 	# for each sector, `start.degree always referto `min.value` and `end.degree` always
-	# refer to `max.value` in a reverse clockwise fasion. So here `start.degree` and 
+	# refer to `max.value` in a reverse clockwise fasion. So here `start.degree` and
 	# `end.degree` also correspond to the direction.
 	# So in the polar coordinate, `start.degree` would be larger than `end.degree`
     names(sector) = c("factor", "min.value", "max.value", "start.degree", "end.degree", "min.data", "max.data")
     sector[["factor"]] = le
 	sector[["min.data"]] = min.value
 	sector[["max.data"]] = max.value
-    
+
     gap.degree = circos.par("gap.degree")
 	if(length(gap.degree) == 1) {
 		gap.degree = rep(gap.degree, n.sector)
 	} else if(length(gap.degree) != n.sector) {
 		stop_wrap("Since `gap.degree` parameter has length larger than 1, it should have same length as number of levels of factors.")
 	}
-	
+
 	start.degree = circos.par("start.degree")
 	clock.wise = circos.par("clock.wise")
-    
+
     if(360 - sum(gap.degree) <= 0) {
 		stop_wrap("Maybe your `gap.degree` is too large so that there is no space to allocate sectors.")
 	}
-		
+
     if(is.null(sector.width)) {
 		# degree per data
 		unit = (360 - sum(gap.degree)) / sum(sector.range)
-		
+
 		for(i in seq_len(n.sector)) {
-			
+
 			if(sector.range[i] == 0) {
 				stop_wrap("Range of the sector ('", le[i] ,"') cannot be 0.")
 			}
-			
+
 			# only to ensure value are always increasing or decreasing with the absolute degree value
 			if(clock.wise) {
 				sector[["start.degree"]][i] = ifelse(i == 1, start.degree, sector[["end.degree"]][i-1] - gap.degree[i-1])
 				sector[["end.degree"]][i] =  sector[["start.degree"]][i] - sector.range[i]*unit
 			} else {
 				sector[["end.degree"]][i] = ifelse(i == 1, start.degree, sector[["start.degree"]][i-1] + gap.degree[i-1])
-				sector[["start.degree"]][i] = sector[["end.degree"]][i] + sector.range[i]*unit   
+				sector[["start.degree"]][i] = sector[["end.degree"]][i] + sector.range[i]*unit
 			}
 		}
 	} else {
@@ -347,28 +347,28 @@ circos.initialize = function(
 		} else if(length(sector.width) != n.sector) {
 			stop_wrap("Since you manually set the width for each sector, the length of `sector.width` should be either 1 or as same as the number of sectors.")
 		}
-		
+
 		sector.width.percentage = sector.width / sum(sector.width)
 		degree.per.sector = (360 - sum(gap.degree)) * sector.width.percentage
-		
+
 		if(any(degree.per.sector <= 0)) {
 			stop_wrap("Maybe your `gap.degree` is too large so that there is no space to allocate sectors.")
 		}
-		
+
 		for(i in seq_len(n.sector)) {
-			
+
 			if(sector.range[i] == 0) {
 				stop_wrap("Range of the sector (", le[i] ,") cannot be 0.")
 			}
-			
-			
+
+
 			# only to ensure value are always increasing or decreasing with the absolute degree value
 			if(clock.wise) {
 				sector[["start.degree"]][i] = ifelse(i == 1, start.degree, sector[["end.degree"]][i-1] - gap.degree[i-1])
 				sector[["end.degree"]][i] =  sector[["start.degree"]][i] - degree.per.sector[i]
 			} else {
 				sector[["end.degree"]][i] = ifelse(i == 1, start.degree, sector[["start.degree"]][i-1] + gap.degree[i-1])
-				sector[["start.degree"]][i] = sector[["end.degree"]][i] + degree.per.sector[i] 
+				sector[["start.degree"]][i] = sector[["end.degree"]][i] + degree.per.sector[i]
 			}
 		}
 	}
@@ -380,32 +380,32 @@ circos.initialize = function(
 		sector[["start.degree"]] = sector[["start.degree"]] + 360
 		sector[["end.degree"]] = sector[["end.degree"]] + 360
 	}
-	
+
 	if(any(cell.padding[2] + cell.padding[4] >= sector[["start.degree"]] - sector[["end.degree"]])) {
 		stop_wrap("Summation of cell padding on x-direction are larger than the width for some sectors. You can e.g. set 'circos.par(cell.padding = c(0.02, 0, 0.02, 0))' or remove tiny sectors.")
 	}
-	
+
 	min.value = min.value - cell.padding[2]/(sector[["start.degree"]] - sector[["end.degree"]] - cell.padding[2] - cell.padding[4])*sector.range  # real min value
     max.value = max.value + cell.padding[4]/(sector[["start.degree"]] - sector[["end.degree"]] - cell.padding[2] - cell.padding[4])*sector.range  # real max value
     sector[["min.value"]] = min.value
     sector[["max.value"]] = max.value
-    
+
     sector = as.data.frame(sector, stringsAsFactors = FALSE)
     .SECTOR.DATA = sector
-    
+
     # initialize .CELL.DATA which contains information of each cell
-    # if content of that cell has been created, it means that the 
+    # if content of that cell has been created, it means that the
     # plotteing region for that cell has been created.
     .CELL.DATA = vector("list", length = length(le))
     names(.CELL.DATA) = le
     for(i in seq_along(.CELL.DATA)) {
         .CELL.DATA[[ le[i] ]] = vector("list", length = 0)
     }
-	
+
 	assign(".SECTOR.DATA", .SECTOR.DATA, envir = .CIRCOS.ENV)
 	assign(".CELL.DATA", .CELL.DATA, envir = .CIRCOS.ENV)
 	assign(".CURRENT.SECTOR.INDEX", .SECTOR.DATA[1, "factor"], envir = .CIRCOS.ENV)
-    
+
     circos.par("__omar__" = FALSE)
 	if(identical(par("mar"), c(5.1, 4.1, 4.1, 2.1))) {
 		circos.par("__omar__" = TRUE)
@@ -413,7 +413,7 @@ circos.initialize = function(
 	}
     # draw everything in a unit circle
 	plot(circos.par("canvas.xlim"), circos.par("canvas.ylim"), type = "n", ann = FALSE, axes = FALSE, asp = 1)
-    
+
 	# all the information of cells would be visited through `get.cell.meta.data`
 	return(invisible(NULL))
 }
@@ -428,7 +428,7 @@ circos.initialize = function(
 #
 # If you meet some errors when re-drawing the circular plot, try running this function and it will solve most of the problems.
 circos.clear = function() {
-    
+
 	resetGlobalVariable()
 	if(circos.par("__omar__")) {
 		circos.par("__omar__" = FALSE)
@@ -485,7 +485,7 @@ get.sector.data = function(sector.index = get.current.sector.index()) {
 # Simply returns the numeric index for the current track.
 get.current.track.index = function() {
 	.CURRENT.TRACK.INDEX = get(".CURRENT.TRACK.INDEX", envir = .CIRCOS.ENV)
-    return(.CURRENT.TRACK.INDEX)   
+    return(.CURRENT.TRACK.INDEX)
 }
 
 set.current.track.index = function(x) {
@@ -501,7 +501,7 @@ set.current.track.index = function(x) {
 # Simply returns the name of current sector
 get.current.sector.index = function() {
 	.CURRENT.SECTOR.INDEX = get(".CURRENT.SECTOR.INDEX", envir = .CIRCOS.ENV)
-    return(.CURRENT.SECTOR.INDEX)   
+    return(.CURRENT.SECTOR.INDEX)
 }
 
 set.current.sector.index = function(x) {
@@ -574,13 +574,13 @@ has.cell = function(sector.index, track.index) {
 #
 # == details
 # It tells you the basic parameters for sectors/tracks/cells. If both ``sector.index``
-# and ``track.index`` are set to ``NULL``, the function would print index for 
+# and ``track.index`` are set to ``NULL``, the function would print index for
 # all sectors and all tracks. If ``sector.index`` and/or ``track.index`` are set,
 # the function would print ``xlim``, ``ylim``, ``cell.xlim``, ``cell.ylim``,
 # ``xplot``, ``yplot``, ``track.margin`` and ``cell.padding`` for every cell in specified sectors and tracks.
 # Also, the function will print index of your current sector and current track.
 #
-# If ``plot`` is set to ``TRUE``, the function will plot the index of the sector and the track 
+# If ``plot`` is set to ``TRUE``, the function will plot the index of the sector and the track
 # for each cell on the figure.
 #
 # == seealso
@@ -588,7 +588,7 @@ has.cell = function(sector.index, track.index) {
 circos.info = function(sector.index = NULL, track.index = NULL, plot = FALSE) {
 	sectors = get.all.sector.index()
 	tracks = get.all.track.index()
-		
+
 	if(plot) {
 		for(i in seq_along(sectors)) {
 			for(j in seq_along(tracks)) {
@@ -645,13 +645,13 @@ circos.info = function(sector.index = NULL, track.index = NULL, plot = FALSE) {
 					cat("\n")
 				}
 			}
-				
+
 		}
 
 		if(length(get.current.sector.index())) cat("Your current sector.index is ", get.current.sector.index(), "\n", sep = "")
 		if(get.current.track.index() > 0) cat("Your current track.index is ", get.current.track.index(), "\n", sep = "")
 	}
-	
+
 }
 
 
@@ -681,9 +681,9 @@ show.index = function() {
 # -``track.index``          Numeric index for the track
 # -``xlim``                 Minimal and maximal values on the x-axis
 # -``ylim``                 Minimal and maximal values on the y-axis
-# -``xrange``               Range of ``xlim``. It equals to ``xlim[2] - xlim[1]`` 
+# -``xrange``               Range of ``xlim``. It equals to ``xlim[2] - xlim[1]``
 # -``yrange``               Range of ``ylim``
-# -``xcenter``              Center of x-axis. It equals to ``(xlim[2] + xlim[1])/2`` 
+# -``xcenter``              Center of x-axis. It equals to ``(xlim[2] + xlim[1])/2``
 # -``ycenter``              Center of y-axis
 # -``cell.xlim``            Minimal and maximal values on the x-axis extended by cell paddings
 # -``cell.ylim``            Minimal and maximal values on the y-axis extended by cell paddings
@@ -710,7 +710,7 @@ show.index = function() {
 # })
 # print(get.cell.meta.data("xlim", sector.index = "a", track.index = 1))
 # circos.clear()
-get.cell.meta.data = function(name, sector.index = get.current.sector.index(), 
+get.cell.meta.data = function(name, sector.index = get.current.sector.index(),
                               track.index = get.current.track.index()) {
 	if(length(sector.index) == 0) {
 		stop_wrap("It seems the circular plot has not been initialized.")
@@ -737,11 +737,11 @@ get.cell.meta.data = function(name, sector.index = get.current.sector.index(),
 	current.sector.data = get.sector.data(sector.index)
 	current.cell.data = get.cell.data(sector.index, track.index)
 	cell.padding = current.cell.data$cell.padding
-	
+
 	if(length(name) != 1) {
 		stop_wrap("``name`` should only have length of 1.")
 	}
-	
+
 	if(name == "xlim") {
 		return(current.cell.data$xlim)
 	} else if(name == "ylim") {
@@ -831,7 +831,7 @@ get.cell.meta.data = function(name, sector.index = get.current.sector.index(),
 CELL_META = "don't use me directly"
 class(CELL_META) = "CELL_META"
 
-# == title 
+# == title
 # Names of all meta data in the current cell
 #
 # == param
@@ -864,9 +864,9 @@ names.CELL_META = function(x) {
 }
 
 # == title
-# Print CELL_META 
+# Print CELL_META
 #
-# == param 
+# == param
 # -x input
 # -... additional parameters
 #

--- a/R/link.R
+++ b/R/link.R
@@ -11,7 +11,7 @@
 #                the link would be a belt/ribbon.
 # -rou           The position of the the link ends (if ``rou1`` and ``rou2`` are not set). It is the percentage of the radius of the unit circle.
 #                By default its value is the position of bottom margin of the most inner track.
-# -rou1          The position of end 1 of the link. 
+# -rou1          The position of end 1 of the link.
 # -rou2          The position of end 2 of the link.
 # -h             Height of the link, measured as percent to the radius to the unit circle. By default it is automatically infered.
 # -h.ratio       systematically change the link height. The value is between 0 and 1.
@@ -39,48 +39,48 @@
 # Drawing links does not create any track. So you can think it is independent of the tracks.
 #
 # By default you only need to set ``sector.index1``, ``point1``, ``sector.index2`` and ``point2``. The
-# links would look nice. 
+# links would look nice.
 #
 # Please refer to the vignette for detailed explanation.
 #
 # == seealso
-# http://jokergoo.github.io/circlize_book/book/graphics.html#links
+# https://jokergoo.github.io/circlize_book/book/graphics.html#links
 #
 circos.link = function(
-	sector.index1, 
-	point1, 
-	sector.index2, 
+	sector.index1,
+	point1,
+	sector.index2,
 	point2,
     rou = get_most_inside_radius(),
-    rou1 = rou, 
-    rou2 = rou, 
-    h = NULL, 
-    h.ratio = 0.5, 
-    w = 1, 
-    h2 = h, 
+    rou1 = rou,
+    rou2 = rou,
+    h = NULL,
+    h.ratio = 0.5,
+    w = 1,
+    h2 = h,
     w2 = w,
-    col = "black", 
-    lwd = par("lwd"), 
-    lty = par("lty"), 
+    col = "black",
+    lwd = par("lwd"),
+    lty = par("lty"),
     border = col,
-    directional = 0, 
-    arr.length = ifelse(arr.type == "big.arrow", 0.02, 0.4), 
-    arr.width = arr.length/2, 
-    arr.type = "triangle", 
-    arr.lty = lty, 
-    arr.lwd = lwd, 
+    directional = 0,
+    arr.length = ifelse(arr.type == "big.arrow", 0.02, 0.4),
+    arr.width = arr.length/2,
+    arr.type = "triangle",
+    arr.lty = lty,
+    arr.lwd = lwd,
     arr.col = col) {
-    
+
     sector.data1 = get.sector.data(sector.index1)
     sector.data2 = get.sector.data(sector.index2)
-	
+
 	point1 = sort(point1)
 	point2 = sort(point2)
 
     if(length(point1) == 1 && length(point2) == 1) {  # single line
         theta1 = circlize(point1, 0, sector.index = sector.index1, track.index = 0)[1, "theta"]
         theta2 = circlize(point2, 0, sector.index = sector.index2, track.index = 0)[1, "theta"]
-        
+
 		d = getQuadraticPoints(theta1, theta2, rou1, rou2, h = h, h.ratio = h.ratio, w = w)
         nr = nrow(d)
         if(directional == 0) {
@@ -98,15 +98,15 @@ circos.link = function(
 	        	alpha = line_degree(d[nr-1, 1], d[nr-1, 2], d[nr, 1], d[nr, 2])
 	        	oljoin = par("ljoin")
 	        	par(ljoin = "mitre")
-	        	Arrowhead(d[nr, 1], d[nr, 2], alpha, arr.length = arr.length, arr.width = arr.width, 
+	        	Arrowhead(d[nr, 1], d[nr, 2], alpha, arr.length = arr.length, arr.width = arr.width,
 	        		arr.adj = 1, arr.lwd = 0.1, arr.type = arr.type, arr.col = col, lcol = col)
 	        	par(ljoin = oljoin)
-	        } 
+	        }
 	        if(directional %in% c(-1,2)) {  # point2 to point2
 	        	alpha = line_degree(d[2, 1], d[2, 2], d[1, 1], d[1,2])
 	        	oljoin = par("ljoin")
 	        	par(ljoin = "mitre")
-	        	Arrowhead(d[1, 1], d[1, 2], alpha, arr.length = arr.length, arr.width = arr.width, 
+	        	Arrowhead(d[1, 1], d[1, 2], alpha, arr.length = arr.length, arr.width = arr.width,
 	        		arr.adj = 1, arr.lwd = 0.1, arr.type = arr.type, arr.col = col, lcol = col)
 	        	par(ljoin = oljoin)
 	        }
@@ -150,7 +150,7 @@ circos.link = function(
 				d = rbind(d1, revMat(r2))
 				d = rbind(d, revMat(d2))
 			}
-			
+
 			polygon(d, col = col, lty = lty, lwd = lwd, border = border)
 			if(nrow(dcenter) > 1 & arr.type != "big.arrow") {
 		        nr = nrow(dcenter)
@@ -165,26 +165,26 @@ circos.link = function(
 		        	alpha = line_degree(dcenter[nr-1, 1], dcenter[nr-1, 2], dcenter[nr, 1], dcenter[nr, 2])
 		        	oljoin = par("ljoin")
 	        		par(ljoin = "mitre")
-		        	Arrowhead(dcenter[nr, 1], dcenter[nr, 2], alpha, arr.length = arr.length, arr.width = arr.width, 
+		        	Arrowhead(dcenter[nr, 1], dcenter[nr, 2], alpha, arr.length = arr.length, arr.width = arr.width,
 		        		arr.adj = 1, arr.lwd = 0.1, arr.type = arr.type, arr.col = arr.col, lcol = arr.col)
 		        	par(ljoin = oljoin)
-		        } 
+		        }
 		        if(directional %in% c(-1,2)) {  # point2 to point1
 		        	alpha = line_degree(dcenter[2, 1], dcenter[2, 2], dcenter[1, 1], dcenter[1,2])
 		        	oljoin = par("ljoin")
 		        	par(ljoin = "mitre")
-		        	Arrowhead(dcenter[1, 1], dcenter[1, 2], alpha, arr.length = arr.length, arr.width = arr.width, 
+		        	Arrowhead(dcenter[1, 1], dcenter[1, 2], alpha, arr.length = arr.length, arr.width = arr.width,
 		        		arr.adj = 1, arr.lwd = 0.1, arr.type = arr.type, arr.col = arr.col, lcol = arr.col)
 		        	par(ljoin = oljoin)
 		        }
 		    }
 		}
-		
+
 	} else if(length(point2) == 1) {
 		theta2 = circlize(point2, 0, sector.index = sector.index2, track.index = 0)[1, "theta"]
 		theta11 = circlize(point1[1], 0, sector.index = sector.index1, track.index = 0)[1, "theta"]
         theta12 = circlize(point1[2], 0, sector.index = sector.index1, track.index = 0)[1, "theta"]
-        
+
         if(degreeDiff2(theta2, theta11) <= degreeDiff2(theta12, theta11) &
            degreeDiff2(theta12, theta2) <= degreeDiff2(theta12, theta11)) {
 			d = getQuadraticPoints(theta12, theta11, max(rou1,rou2), max(rou1,rou2), h = h, h.ratio = h.ratio, w = w)
@@ -233,23 +233,23 @@ circos.link = function(
 		        	alpha = line_degree(dcenter[nr-1, 1], dcenter[nr-1, 2], dcenter[nr, 1], dcenter[nr, 2])
 		        	oljoin = par("ljoin")
 	        		par(ljoin = "mitre")
-	        		Arrowhead(dcenter[nr, 1], dcenter[nr, 2], alpha, arr.length = arr.length, arr.width = arr.width, 
+	        		Arrowhead(dcenter[nr, 1], dcenter[nr, 2], alpha, arr.length = arr.length, arr.width = arr.width,
 		        		arr.adj = 1, arr.lwd = 0.1, arr.type = arr.type, arr.col = arr.col, lcol = arr.col)
 	        		par(ljoin = oljoin)
-		        } 
+		        }
 		        if(directional %in% c(-1,2)) {  # point2 to point1
 		        	alpha = line_degree(dcenter[2, 1], dcenter[2, 2], dcenter[1, 1], dcenter[1,2])
 		        	oljoin = par("ljoin")
 		        	par(ljoin = "mitre")
-		        	Arrowhead(dcenter[1, 1], dcenter[1, 2], alpha, arr.length = arr.length, arr.width = arr.width, 
+		        	Arrowhead(dcenter[1, 1], dcenter[1, 2], alpha, arr.length = arr.length, arr.width = arr.width,
 		        		arr.adj = 1, arr.lwd = 0.1, arr.type = arr.type, arr.col = arr.col, lcol = arr.col)
 		        	par(ljoin = oljoin)
 		        }
 		    }
 		}
-		
+
 	} else {
-		
+
 		theta11 = circlize(point1[1], 0, sector.index = sector.index1, track.index = 0)[1, "theta"]
         theta12 = circlize(point1[2], 0, sector.index = sector.index1, track.index = 0)[1, "theta"]
 		theta21 = circlize(point2[1], 0, sector.index = sector.index2, track.index = 0)[1, "theta"]
@@ -343,22 +343,22 @@ circos.link = function(
 		        	alpha = line_degree(dcenter[nr-1, 1], dcenter[nr-1, 2], dcenter[nr, 1], dcenter[nr, 2])
 		        	oljoin = par("ljoin")
 	        		par(ljoin = "mitre")
-		        	Arrowhead(dcenter[nr, 1], dcenter[nr, 2], alpha, arr.length = arr.length, arr.width = arr.width, 
+		        	Arrowhead(dcenter[nr, 1], dcenter[nr, 2], alpha, arr.length = arr.length, arr.width = arr.width,
 		        		arr.adj = 1.5, arr.lwd = 0.1, arr.type = arr.type, arr.col = arr.col, lcol = arr.col)
 		        	par(ljoin = oljoin)
-		        } 
+		        }
 		        if(directional %in% c(-1,2)) {  # point2 to point1
 		        	alpha = line_degree(dcenter[2, 1], dcenter[2, 2], dcenter[1, 1], dcenter[1,2])
 		        	oljoin = par("ljoin")
 		        	par(ljoin = "mitre")
-		        	Arrowhead(dcenter[1, 1], dcenter[1, 2], alpha, arr.length = arr.length, arr.width = arr.width, 
+		        	Arrowhead(dcenter[1, 1], dcenter[1, 2], alpha, arr.length = arr.length, arr.width = arr.width,
 		        		arr.adj = 1, arr.lwd = 0.1, arr.type = arr.type, arr.col = arr.col, lcol = arr.col)
 		        	par(ljoin = oljoin)
 		        }
 		    }
 		}
     }
-	
+
     return(invisible(NULL))
 }
 
@@ -371,7 +371,7 @@ arc.points = function(theta1, theta2, rou) {
 	ncut = l/ (2*pi/circos.par("unit.circle.segments"))
 	ncut = floor(ncut)
 	ncut = ifelse(ncut < 2, 2, ncut)
-    
+
 	x = rou * cos(as.radian(theta1 + seq_len(ncut-1)*theta_diff/(ncut-1)))
 	y = rou * sin(as.radian(theta1 + seq_len(ncut-1)*theta_diff/(ncut-1)))
 	d = cbind(x, y)
@@ -412,29 +412,29 @@ getQuadraticPoints = function(theta1, theta2, rou1, rou2, h = NULL, h.ratio = 0.
 	rou_min = min(rou1, rou2)
 	x1 = rou_min*cos(as.radian(theta1))
 	y1 = rou_min*sin(as.radian(theta1))
-	
+
 	x2 = rou_min*cos(as.radian(theta2))
 	y2 = rou_min*sin(as.radian(theta2))
-	
+
 	# determin h
 	beta = (theta1 - theta2) %% 360
 	if(beta > 180) beta = 360 - beta
 	h_auto = rou_min*(1-h.ratio*cos(as.radian(beta/2)))
-	
+
 	if(is.null(h)) {
 		h = h_auto
 	}
 	if(length(h) == 0) {
-		h = h_auto	
+		h = h_auto
 	}
 	if(h > rou_min) {
 		h = h_auto
 	}
-	
+
 	h2 = h - rou_min*(1-cos(as.radian(beta/2)))
-	
+
 	if(w < 0) h2 = -h2
-	
+
 	dis = 1/2 * sqrt((x1 - x2)^2 + (y1 - y2)^2)
 	p0 = c(-dis, 0)
 	p2 = c(dis, 0)
@@ -443,7 +443,7 @@ getQuadraticPoints = function(theta1, theta2, rou1, rou2, h = NULL, h.ratio = 0.
 	} else {
 		p1 = c(0, (1+w)/w*h2)
 	}
-	
+
 	d = quadratic.bezier(p0, p1, p2, w = w)
 
 	# shit, I don't know why!
@@ -454,14 +454,14 @@ getQuadraticPoints = function(theta1, theta2, rou1, rou2, h = NULL, h.ratio = 0.
 		alpha = alpha + 180
 		col = "green"
 	}
-	
+
 	# rotate coordinate
 	mat = matrix(c(cos(as.radian(alpha)), sin(as.radian(alpha)), -sin(as.radian(alpha)), cos(as.radian(alpha))), nrow = 2)
 	d = d %*% mat
-	
+
 	x0 = (x1+x2)/2
 	y0 = (y1+y2)/2
-	
+
 	d[, 1] = d[, 1] + x0
 	d[, 2] = d[, 2] + y0
 
@@ -470,7 +470,7 @@ getQuadraticPoints = function(theta1, theta2, rou1, rou2, h = NULL, h.ratio = 0.
 	}
 
 	#points(rou_min*cos(as.radian(theta1)), rou_min*sin(as.radian(theta1)), pch = 16, col = "blue")
-	
+
 	if(rou1 > rou2) {
 		d = rbind(c(rou1*cos(as.radian(theta1)), rou1*sin(as.radian(theta1))), d)
 	} else if(rou1 < rou2) {
@@ -509,18 +509,18 @@ quadratic.bezier.length = function(p0, p1, p2, w = 1) {
 are.lines.intersected = function(x1, y1, x2, y2) {
 	n1 = length(x1)
 	n2 = length(x2)
-	
+
 	for(i in seq_len(n1)) {
 		if(i == 1) next
-		
+
 		a_1x = x1[i-1]
 		a_1y = y1[i-1]
 		a_2x = x1[i]
 		a_2y = y1[i]
-			
+
 		k1 = (a_1y - a_2y)/(a_1x - a_2x)
-		b1 = a_1y - k1*a_1x	
-						
+		b1 = a_1y - k1*a_1x
+
 		for(j in seq_len(n2)) {
 			if(j == 1) next
 
@@ -528,14 +528,14 @@ are.lines.intersected = function(x1, y1, x2, y2) {
 			b_1y = y2[j-1]
 			b_2x = x2[j]
 			b_2y = y2[j]
-			
-			
+
+
 			k2 = (b_1y - b_2y)/(b_1x - b_2x)
 			b2 = b_1y - k2*b_1x
-				
+
 			i_x = - (b2 - b1)/(k2 - k1)
 			i_y = k1*i_x + b1
-			
+
 			a_minx = min(c(a_1x, a_2x))
 			a_maxx = max(c(a_1x, a_2x))
 			b_minx = min(c(b_1x, b_2x))

--- a/R/overview.R
+++ b/R/overview.R
@@ -6,10 +6,10 @@
 #
 # This package aims to implement circular layout in R.
 #
-# Since most of the figures are composed of points, lines and polygons, 
+# Since most of the figures are composed of points, lines and polygons,
 # we just need to implement low-level functions for drawing points, lines and polygons.
 #
-# Current there are following low-level graphic functions: 
+# Current there are following low-level graphic functions:
 #
 # - `circos.points`
 # - `circos.lines`
@@ -19,55 +19,55 @@
 # - `circos.text`
 # - `circos.axis`, `circos.xaxis`, `circos.yaxis`
 # - `circos.link`
-#  
-# For drawing points, lines and text through the whole track (among several sectors), the following 
+#
+# For drawing points, lines and text through the whole track (among several sectors), the following
 # functions are available:
-# 
+#
 # - `circos.trackPoints`
 # - `circos.trackLines`
 # - `circos.trackText`
-# 
+#
 # Functions to arrange circular layout:
-# 
+#
 # - `circos.initialize`
 # - `circos.track`
 # - `circos.update`
 # - `circos.par`
 # - `circos.info`
 # - `circos.clear`
-# 
+#
 # Theoretically, you are able to draw most kinds of circular plots by the above functions.
-# 
+#
 # For specific use in genomics, we also implement functions which add graphics in genome scale.
-# 
+#
 # Functions to initialize circos plot with genomic coordinates:
-#  
+#
 # - `circos.initializeWithIdeogram`
 # - `circos.genomicInitialize`
-# 
+#
 # Functions to arrange genomic circular layout:
-# 
+#
 # - `circos.genomicTrack`
-# 
+#
 # Functions to add basic graphics in genomic scale:
-# 
+#
 # - `circos.genomicPoints`
 # - `circos.genomicLines`
 # - `circos.genomicText`
 # - `circos.genomicRect`
 # - `circos.genomicLink`
-# 
+#
 # Functions with specific purpose:
-# 
+#
 # - `circos.genomicDensity`
 # - `circos.genomicRainfall`
 # - `circos.genomicIdeogram`
 # - `circos.genomicHeatmap`
 # - `circos.genomicLabels`
-# 
+#
 # Finally, function that draws Chord diagram:
-# 
+#
 # - `chordDiagram`
 #
-# Please refer to the vignettes (http://jokergoo.github.io/circlize_book/book/ ) to find out how to draw basic and advanced circular plots by this package.
-# 
+# Please refer to the vignettes (https://jokergoo.github.io/circlize_book/book/ ) to find out how to draw basic and advanced circular plots by this package.
+#

--- a/R/plot.R
+++ b/R/plot.R
@@ -64,7 +64,7 @@
 # See vignette for examples of how to use this feature.
 #
 # == seealso
-# http://jokergoo.github.io/circlize_book/book/circular-layout.html
+# https://jokergoo.github.io/circlize_book/book/circular-layout.html
 #
 # == example
 # circos.initialize(letters[1:8], xlim = c(0, 1))
@@ -77,17 +77,17 @@
 # }, track.height = 0.2, bg.border = rand_color(8))
 # circos.clear()
 circos.trackPlotRegion = function(
-	factors = NULL, 
-	x = NULL, y = NULL, 
+	factors = NULL,
+	x = NULL, y = NULL,
 	ylim = NULL,
-    force.ylim = TRUE, 
+    force.ylim = TRUE,
     track.index = NULL,
 	track.height = circos.par("track.height"),
 	track.margin = circos.par("track.margin"),
 	cell.padding = circos.par("cell.padding"),
-    bg.col = NA, 
-    bg.border = "black", 
-    bg.lty = par("lty"), 
+    bg.col = NA,
+    bg.border = "black",
+    bg.lty = par("lty"),
     bg.lwd = par("lwd"),
     panel.fun = function(x, y) {NULL}) {
 
@@ -296,9 +296,9 @@ circos.track = function(...) {
 circos.updatePlotRegion = function(
 	sector.index = get.cell.meta.data("sector.index"),
     track.index = get.cell.meta.data("track.index"),
-    bg.col = NA, 
-    bg.border = "black", 
-    bg.lty = par("lty"), 
+    bg.col = NA,
+    bg.border = "black",
+    bg.lty = par("lty"),
     bg.lwd = par("lwd")) {
 
     if(!has.cell(sector.index, track.index)) {
@@ -335,14 +335,14 @@ circos.update = function(...)  {
 
 # internal, so we do not need to check arguments
 circos.createPlotRegion = function(
-	track.start, 
+	track.start,
 	track.height = circos.par("track.height"),
-    sector.index = get.cell.meta.data("sector.index"), 
-    track.index = get.cell.meta.data("track.index"), 
+    sector.index = get.cell.meta.data("sector.index"),
+    track.index = get.cell.meta.data("track.index"),
     ylim,
-    bg.col = NA, 
-    bg.border = "black", 
-    bg.lty = par("lty"), 
+    bg.col = NA,
+    bg.border = "black",
+    bg.lty = par("lty"),
     bg.lwd = par("lwd")) {
 
 	# we do not have such meta for the cell, so we need to calculate them
@@ -431,12 +431,12 @@ circos.createPlotRegion = function(
 # circos.points(runif(10), runif(10), sector.index = "c", pch = 16, col = "red")
 # circos.clear()
 circos.points = function(
-	x, y, 
+	x, y,
 	sector.index = get.cell.meta.data("sector.index"),
     track.index = get.cell.meta.data("track.index"),
-    pch = par("pch"), 
-    col = par("col"), 
-    cex = par("cex"), 
+    pch = par("pch"),
+    col = par("col"),
+    cex = par("cex"),
     bg = par("bg")) {
 
     if(!has.cell(sector.index, track.index)) {
@@ -491,12 +491,12 @@ circos.points = function(
 # circos.trackPoints(df$fa, x = df$x, y = df$y, pch = 16, col = as.numeric(factor(df$fa)))
 # circos.clear()
 circos.trackPoints = function(
-	factors = NULL, 
-	x, y, 
+	factors = NULL,
+	x, y,
 	track.index = get.cell.meta.data("track.index"),
-    pch = par("pch"), 
-    col = par("col"), 
-    cex = par("cex"), 
+    pch = par("pch"),
+    col = par("col"),
+    cex = par("cex"),
     bg = par("bg")) {
 
     # basic check here
@@ -605,19 +605,19 @@ circos.trackPoints = function(
 #
 # circos.clear()
 circos.lines = function(
-	x, y, 
+	x, y,
 	sector.index = get.cell.meta.data("sector.index"),
     track.index = get.cell.meta.data("track.index"),
-    col = ifelse(area, "grey", par("col")), 
-    lwd = par("lwd"), 
+    col = ifelse(area, "grey", par("col")),
+    lwd = par("lwd"),
     lty = par("lty"),
-    type = "l", 
-    straight = FALSE, 
-    area = FALSE, 
+    type = "l",
+    straight = FALSE,
+    area = FALSE,
     area.baseline = NULL,
-    border = "black", 
-    baseline = "bottom", 
-    pt.col = par("col"), 
+    border = "black",
+    baseline = "bottom",
+    pt.col = par("col"),
     cex = par("cex"),
     pch = par("pch")) {
 
@@ -733,20 +733,20 @@ circos.lines = function(
 #
 # This function can be replaced by a ``for`` loop containing `circos.lines`.
 circos.trackLines = function(
-	factors, 
-	x, y, 
+	factors,
+	x, y,
 	track.index = get.cell.meta.data("track.index"),
-    col = par("col"), 
-    lwd = par("lwd"), 
-    lty = par("lty"), 
-    type = "l", 
+    col = par("col"),
+    lwd = par("lwd"),
+    lty = par("lty"),
+    type = "l",
     straight = FALSE,
-	area = FALSE, 
-	area.baseline = NULL, 
-	border = "black", 
+	area = FALSE,
+	area.baseline = NULL,
+	border = "black",
 	baseline = "bottom",
-    pt.col = par("col"), 
-    cex = par("cex"), 
+    pt.col = par("col"),
+    cex = par("cex"),
     pch = par("pch")) {
 
 	if(!is.null(area.baseline)) {
@@ -836,8 +836,8 @@ circos.trackLines = function(
 circos.rect = function(
 	xleft, ybottom, xright, ytop,
 	sector.index = get.cell.meta.data("sector.index"),
-	track.index = get.cell.meta.data("track.index"), 
-	rot = 0, 
+	track.index = get.cell.meta.data("track.index"),
+	rot = 0,
 	...) {
 
     # if(! (length(xleft) == 1 &&
@@ -942,7 +942,7 @@ circos.rect = function(
 # circos.initialize(fa = c("a", "b", "c", "d"), xlim = c(0, 10))
 # circos.track(ylim = c(0, 10), panel.fun = function(x, y) {
 #     circos.triangle(c(2, 2), c(2, 8),
-#                     c(8, 8), c(2, 8), 
+#                     c(8, 8), c(2, 8),
 #                     c(5, 5), c(8, 2))
 # }, track.height = 0.5)
 #
@@ -1028,9 +1028,9 @@ circos.triangle = function(x1, y1, x2, y2, x3, y3, ...) {
 # })
 # circos.clear()
 circos.polygon = function(
-	x, y, 
+	x, y,
 	sector.index = get.cell.meta.data("sector.index"),
-	track.index = get.cell.meta.data("track.index"), 
+	track.index = get.cell.meta.data("track.index"),
 	...) {
 
     if(!has.cell(sector.index, track.index)) {
@@ -1063,13 +1063,13 @@ circos.polygon = function(
 # -... pass to `graphics::lines`
 #
 circos.segments = function(
-	x0, y0, x1, y1, 
+	x0, y0, x1, y1,
 	sector.index = get.cell.meta.data("sector.index"),
-	track.index = get.cell.meta.data("track.index"), 
+	track.index = get.cell.meta.data("track.index"),
 	straight = FALSE,
-	col = par("col"), 
-	lwd = par("lwd"), 
-	lty = par("lty"), 
+	col = par("col"),
+	lwd = par("lwd"),
+	lty = par("lty"),
 	...) {
 
 	n1 = length(x0)
@@ -1172,40 +1172,40 @@ circos.segments = function(
 # The function is similar to `graphics::text`. All you need to note is the ``facing`` settings.
 #
 # == seealso
-# http://jokergoo.github.io/circlize_book/book/graphics.html#text
+# https://jokergoo.github.io/circlize_book/book/graphics.html#text
 #
 # == example
 # factors = letters[1:4]
 # circos.par(points.overflow.warning = FALSE)
 # circos.initialize(factors = factors, xlim = c(0, 10))
-# circos.trackPlotRegion(factors = factors, ylim = c(0, 10), 
+# circos.trackPlotRegion(factors = factors, ylim = c(0, 10),
 #   track.height = 0.5, panel.fun = function(x, y) {
 #     circos.text(3, 1, "inside", facing = "inside", cex = 0.8)
 #     circos.text(7, 1, "outside", facing = "outside", cex = 0.8)
-#     circos.text(0, 5, "reverse.clockwise", facing = "reverse.clockwise", 
+#     circos.text(0, 5, "reverse.clockwise", facing = "reverse.clockwise",
 #         adj = c(0.5, 0), cex = 0.8)
-#     circos.text(10, 5, "clockwise", facing = "clockwise", adj = c(0.5, 0), 
+#     circos.text(10, 5, "clockwise", facing = "clockwise", adj = c(0.5, 0),
 #         cex = 0.8)
 #     circos.text(5, 5, "downward", facing = "downward", cex = 0.8)
-#     circos.text(3, 9, "====bending.inside====", facing = "bending.inside", 
+#     circos.text(3, 9, "====bending.inside====", facing = "bending.inside",
 #         cex = 0.8)
-#     circos.text(7, 9, "====bending.outside====", facing = "bending.outside", 
+#     circos.text(7, 9, "====bending.outside====", facing = "bending.outside",
 #         cex = 0.8)
 # })
 # circos.clear()
 circos.text = function(
-	x, y, 
-	labels, 
+	x, y,
+	labels,
 	sector.index = get.cell.meta.data("sector.index"),
-    track.index = get.cell.meta.data("track.index"), 
+    track.index = get.cell.meta.data("track.index"),
     direction = NULL,
     facing = c("inside", "outside", "reverse.clockwise", "clockwise",
-	    "downward", "bending", "bending.inside", "bending.outside"), 
+	    "downward", "bending", "bending.inside", "bending.outside"),
     niceFacing = FALSE,
-	adj = par("adj"), 
-	cex = 1, 
-	col = par("col"), 
-	font = par("font"), 
+	adj = par("adj"),
+	cex = 1,
+	col = par("col"),
+	font = par("font"),
 	...) {
 
     len_x = length(x)
@@ -1468,17 +1468,17 @@ degree = function(x) {
 #
 # This function can be replaced by a ``for`` loop containing `circos.text`.
 circos.trackText = function(
-	factors, 
-	x, y, 
-	labels, 
+	factors,
+	x, y,
+	labels,
 	track.index = get.cell.meta.data("track.index"),
-    direction = NULL, 
+    direction = NULL,
     facing = c("inside", "outside", "reverse.clockwise", "clockwise",
-	    "downward", "bending", "bending.inside", "bending.outside"), 
+	    "downward", "bending", "bending.inside", "bending.outside"),
     niceFacing = FALSE,
-    adj = par("adj"), 
-    cex = 1, 
-    col = par("col"), 
+    adj = par("adj"),
+    cex = 1,
+    col = par("col"),
     font = par("font")) {
 
     # basic check here
@@ -1604,7 +1604,7 @@ circos.trackText = function(
 #     sec = ceiling(current.time$sec)
 #     min = current.time$min
 #     hour = current.time$hour
-#    
+#
 #     # erase the clock hands
 #     draw.sector(rou1 = 0.8, border = "white", col = "white")
 #
@@ -1612,35 +1612,35 @@ circos.trackText = function(
 #     arrows(0, 0, cos(sec.degree/180*pi)*0.8, sin(sec.degree/180*pi)*0.8)
 #
 #     min.degree = 90 - min/60 * 360
-#     arrows(0, 0, cos(min.degree/180*pi)*0.7, sin(min.degree/180*pi)*0.7, lwd = 2)   
+#     arrows(0, 0, cos(min.degree/180*pi)*0.7, sin(min.degree/180*pi)*0.7, lwd = 2)
 #
 #     hour.degree = 90 - hour/12 * 360 - min/60 * 360/12
 #     arrows(0, 0, cos(hour.degree/180*pi)*0.4, sin(hour.degree/180*pi)*0.4, lwd = 2)
-#    
+#
 #     Sys.sleep(1)
 # }
 # circos.clear()
 # }
 circos.axis = function(
-	h = "top", 
-	major.at = NULL, 
-	labels = TRUE, 
+	h = "top",
+	major.at = NULL,
+	labels = TRUE,
 	major.tick = TRUE,
 	sector.index = get.cell.meta.data("sector.index"),
 	track.index = get.cell.meta.data("track.index"),
-	labels.font = par("font"), 
+	labels.font = par("font"),
 	labels.cex = par("cex"),
-	labels.facing = "inside", 
-	labels.direction = NULL, 
+	labels.facing = "inside",
+	labels.direction = NULL,
 	labels.niceFacing = TRUE,
-	direction = c("outside", "inside"), 
+	direction = c("outside", "inside"),
 	minor.ticks = 4,
-	major.tick.percentage = 0.1, 
+	major.tick.percentage = 0.1,
 	labels.away.percentage = major.tick.percentage/2,
 	major.tick.length = convert_y(1, "mm", sector.index, track.index),
-	lwd = par("lwd"), 
-	col = par("col"), 
-	labels.col = par("col"), 
+	lwd = par("lwd"),
+	col = par("col"),
+	labels.col = par("col"),
 	labels.pos.adjust = TRUE) {
 
     if(!is.null(labels.direction)) {
@@ -1749,7 +1749,7 @@ circos.axis = function(
 		n = length(x)
 		first_label_width = convert_x(strwidth(labels[1], units = "inches", cex = arg_list$cex), "inches", arg_list$sector.index, arg_list$track.index, h = h)
         first_label_height = convert_x(strheight(labels[1], units = "inches", cex = arg_list$cex), "inches", arg_list$sector.index, arg_list$track.index, h = h)
-            
+
         if(n >= 1) {
 			last_label_width = convert_x(strwidth(labels[n], units = "inches", cex = arg_list$cex), "inches", arg_list$sector.index, arg_list$track.index, h = h)
 			last_label_height = convert_x(strheight(labels[n], units = "inches", cex = arg_list$cex), "inches", arg_list$sector.index, arg_list$track.index, h = h)
@@ -1904,18 +1904,18 @@ circos.xaxis = function(...) {
 #
 # par(op)
 circos.yaxis = function(
-	side = c("left", "right"), 
-	at = NULL, 
-	labels = TRUE, 
+	side = c("left", "right"),
+	at = NULL,
+	labels = TRUE,
 	tick = TRUE,
 	sector.index = get.cell.meta.data("sector.index"),
 	track.index = get.cell.meta.data("track.index"),
-	labels.font = par("font"), 
+	labels.font = par("font"),
 	labels.cex = par("cex"),
 	labels.niceFacing = TRUE,
 	tick.length = convert_x(1, "mm", sector.index, track.index),
-	lwd = par("lwd"), 
-	col = par("col"), 
+	lwd = par("lwd"),
+	col = par("col"),
 	labels.col = par("col")) {
 
 	ylim = get.cell.meta.data("ylim", sector.index, track.index)
@@ -2021,33 +2021,33 @@ circos.yaxis = function(
 # x = rnorm(1600)
 # factors = sample(letters[1:16], 1600, replace = TRUE)
 # circos.initialize(factors = factors, x = x)
-# circos.trackHist(factors = factors, x = x, col = "#999999", 
+# circos.trackHist(factors = factors, x = x, col = "#999999",
 #   border = "#999999")
-# circos.trackHist(factors = factors, x = x, bin.size = 0.1, 
+# circos.trackHist(factors = factors, x = x, bin.size = 0.1,
 #   col = "#999999", border = "#999999")
-# circos.trackHist(factors = factors, x = x, draw.density = TRUE, 
+# circos.trackHist(factors = factors, x = x, draw.density = TRUE,
 #   col = "#999999", border = "#999999")
 # circos.clear()
 #
 circos.trackHist = function(
-	factors, 
-	x, 
+	factors,
+	x,
 	track.height = circos.par("track.height"),
-    track.index = NULL, 
-    force.ylim = TRUE, 
+    track.index = NULL,
+    force.ylim = TRUE,
     col = ifelse(draw.density, "black", NA),
-	border = "black", 
-	lty = par("lty"), 
+	border = "black",
+	lty = par("lty"),
 	lwd = par("lwd"),
-    bg.col = NA, 
-    bg.border = "black", 
-    bg.lty = par("lty"), 
+    bg.col = NA,
+    bg.border = "black",
+    bg.lty = par("lty"),
     bg.lwd = par("lwd"),
-    breaks = "Sturges", 
-    include.lowest = TRUE, 
-    right = TRUE, 
+    breaks = "Sturges",
+    include.lowest = TRUE,
+    right = TRUE,
     draw.density = FALSE,
-    bin.size = NULL, 
+    bin.size = NULL,
     area = FALSE) {
 
     # basic check here
@@ -2184,8 +2184,8 @@ circos.trackHist = function(
 # draw.sector(get.cell.meta.data("cell.start.degree", sector.index = "a"),
 #             get.cell.meta.data("cell.end.degree", sector.index = "a"),
 #             rou1 = 1, col = "#FF000040")
-#            
-# draw.sector(0, 360, 
+#
+# draw.sector(0, 360,
 #     rou1 = get.cell.meta.data("cell.top.radius", track.index = 1),
 #     rou2 = get.cell.meta.data("cell.bottom.radius", track.index = 1),
 #     col = "#00FF0040")
@@ -2195,20 +2195,20 @@ circos.trackHist = function(
 #             get.cell.meta.data("cell.top.radius", track.index = 2),
 #             get.cell.meta.data("cell.bottom.radius", track.index = 3),
 #             col = "#0000FF40")
-#            
+#
 # pos = circlize(c(0.2, 0.8), c(0.2, 0.8), sector.index = "h", track.index = 2)
-# draw.sector(pos[1, "theta"], pos[2, "theta"], pos[1, "rou"], pos[2, "rou"], 
+# draw.sector(pos[1, "theta"], pos[2, "theta"], pos[1, "rou"], pos[2, "rou"],
 #     clock.wise = TRUE, col = "#00FFFF40")
 # circos.clear()
 draw.sector = function(
-	start.degree = 0, 
-	end.degree = 360, 
-	rou1 = 1, 
+	start.degree = 0,
+	end.degree = 360,
+	rou1 = 1,
 	rou2 = NULL,
-	center = c(0, 0), 
-	clock.wise = TRUE, 
-	col = NA, 
-	border = "black", 
+	center = c(0, 0),
+	clock.wise = TRUE,
+	col = NA,
+	border = "black",
 	lwd = par("lwd"),
 	lty = par("lty")) {
 
@@ -2348,21 +2348,21 @@ draw.sector = function(
 # highlight.sector("c", col = "#00FF0040")
 # highlight.sector("d", col = NA, border = "red", lwd = 2)
 # highlight.sector("e", col = "#0000FF40", track.index = c(2, 3))
-# highlight.sector(c("f", "g"), col = NA, border = "green", 
+# highlight.sector(c("f", "g"), col = NA, border = "green",
 #     lwd = 2, track.index = c(2, 3))
 # highlight.sector(factors, col = "#FFFF0040", track.index = 4)
 # circos.clear()
 highlight.sector = function(
-	sector.index, 
+	sector.index,
 	track.index = get.all.track.index(),
-	col = "#FF000040", 
-	border = NA, 
-	lwd = par("lwd"), 
+	col = "#FF000040",
+	border = NA,
+	lwd = par("lwd"),
 	lty = par("lty"),
-	padding = c(0, 0, 0, 0), 
-	text = NULL, 
+	padding = c(0, 0, 0, 0),
+	text = NULL,
 	text.col = par("col"),
-	text.vjust = 0.5, 
+	text.vjust = 0.5,
 	...) {
 
 	sectors = get.all.sector.index()
@@ -2496,10 +2496,10 @@ parse_unit = function(str) {
 # circos.par(cell.padding = c(0, 0, 0, 0))
 # circos.initialize(factors = "a", xlim = c(0, n)) # only one sector
 # max_height = attr(dend, "height")  # maximum height of the trees
-# circos.trackPlotRegion(ylim = c(0, 1), bg.border = NA, track.height = 0.3, 
+# circos.trackPlotRegion(ylim = c(0, 1), bg.border = NA, track.height = 0.3,
 #     panel.fun = function(x, y) {
 #         for(i in seq_len(n)) {
-#             circos.text(i-0.5, 0, labels[i], adj = c(0, 0.5), 
+#             circos.text(i-0.5, 0, labels[i], adj = c(0, 0.5),
 #                 facing = "clockwise", niceFacing = TRUE,
 #                 col = ct[labels[i]], cex = 0.7)
 #         }
@@ -2508,15 +2508,15 @@ parse_unit = function(str) {
 # suppressPackageStartupMessages(require(dendextend))
 # dend = color_branches(dend, k = 6, col = 1:6)
 #
-# circos.trackPlotRegion(ylim = c(0, max_height), bg.border = NA, 
+# circos.trackPlotRegion(ylim = c(0, max_height), bg.border = NA,
 #     track.height = 0.4, panel.fun = function(x, y) {
 #         circos.dendrogram(dend, max_height = max_height)
 # })
 # circos.clear()
 circos.dendrogram = function(
-	dend, 
-	facing = c("outside", "inside"), 
-    max_height = NULL, 
+	dend,
+	facing = c("outside", "inside"),
+    max_height = NULL,
     use_x_attr = FALSE) {
 
 	facing = match.arg(facing)[1]
@@ -2533,7 +2533,7 @@ circos.dendrogram = function(
             leaf
         }
     }
-	
+
     use_x_attr = use_x_attr
 
     lines_par = function(col = par("col"), lty = par("lty"), lwd = par("lwd"), ...) {
@@ -2550,9 +2550,9 @@ circos.dendrogram = function(
         d2 = dend[[2]]  # child tree 2
         height = attr(dend, "height")
         midpoint = attr(dend, "midpoint")
-	
+
         if(use_x_attr) {
-            x1 = attr(d1, "x")	
+            x1 = attr(d1, "x")
         } else {
             if(is.leaf(d1)) {
                 x1 = x[as.character(attr(d1, "label"))]
@@ -2563,7 +2563,7 @@ circos.dendrogram = function(
         y1 = attr(d1, "height")
 
         if(use_x_attr) {
-            x2 = attr(d2, "x")	
+            x2 = attr(d2, "x")
         } else {
             if(is.leaf(d2)) {
                 x2 = x[as.character(attr(d2, "label"))]

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,10 +9,10 @@ setLoadActions(function(ns) {
 ", pkgname, " version ", version, "
 CRAN page: https://cran.r-project.org/package=circlize
 Github page: https://github.com/jokergoo/circlize
-Documentation: http://jokergoo.github.io/circlize_book/book/
+Documentation: https://jokergoo.github.io/circlize_book/book/
 
 If you use it in published research, please cite:
-Gu, Z. circlize implements and enhances circular visualization 
+Gu, Z. circlize implements and enhances circular visualization
   in R. Bioinformatics 2014.
 
 This message can be suppressed by:

--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
 
 
-# circlize: circular visualization in R <a href="http://jokergoo.github.io/circlize_book/book/"><img src="http://jokergoo.github.io/circlize_book/book/images/circlize_cover.jpg" width=240 align="right" ></a>
+# circlize: circular visualization in R <a href="https://jokergoo.github.io/circlize_book/book/"><img src="https://jokergoo.github.io/circlize_book/book/images/circlize_cover.jpg" width=240 align="right" ></a>
 
 
 [![Build Status](https://travis-ci.org/jokergoo/circlize.svg)](https://travis-ci.org/jokergoo/circlize)
 [![codecov](https://img.shields.io/codecov/c/github/jokergoo/circlize.svg)](https://codecov.io/github/jokergoo/circlize)
-[![CRAN](http://www.r-pkg.org/badges/version/circlize)](https://cran.r-project.org/web/packages/circlize/index.html) 
-[![CRAN](https://cranlogs.r-pkg.org/badges/grand-total/circlize)](https://cran.r-project.org/web/packages/circlize/index.html) 
+[![CRAN](https://www.r-pkg.org/badges/version/circlize)](https://cran.r-project.org/web/packages/circlize/index.html)
+[![CRAN](https://cranlogs.r-pkg.org/badges/grand-total/circlize)](https://cran.r-project.org/web/packages/circlize/index.html)
 
-Circular layout is an efficient way for the visualization of huge 
-    amounts of information. Here the circlize package provides an implementation 
-    of circular layout generation in R as well as an enhancement of available 
-    software. The flexibility of this package is based on the usage of low-level 
-    graphics functions such that self-defined high-level graphics can be easily 
-    implemented by users for specific purposes. Together with the seamless 
-    connection between the powerful computational and visual environment in R, 
-    circlize givesa users more convenience and freedom to design figures for 
+Circular layout is an efficient way for the visualization of huge
+    amounts of information. Here the circlize package provides an implementation
+    of circular layout generation in R as well as an enhancement of available
+    software. The flexibility of this package is based on the usage of low-level
+    graphics functions such that self-defined high-level graphics can be easily
+    implemented by users for specific purposes. Together with the seamless
+    connection between the powerful computational and visual environment in R,
+    circlize givesa users more convenience and freedom to design figures for
     better understanding complex patterns behind multi-dimensional data.
 
 ## Citation
 
-Zuguang Gu, Lei Gu, Roland Eils, Matthias Schlesner, Benedikt Brors, circlize Implements and enhances circular visualization in R. Bioinformatics (Oxford, England) 2014. [PubMed](http://www.ncbi.nlm.nih.gov/pubmed/24930139)
+Zuguang Gu, Lei Gu, Roland Eils, Matthias Schlesner, Benedikt Brors, circlize Implements and enhances circular visualization in R. Bioinformatics (Oxford, England) 2014. [PubMed](https://www.ncbi.nlm.nih.gov/pubmed/24930139)
 
 ## Documentation
 
-The full documentations are available at http://jokergoo.github.io/circlize_book/book/ and the online website is at https://jokergoo.github.io/circlize/.
+The full documentations are available at https://jokergoo.github.io/circlize_book/book/ and the online website is at https://jokergoo.github.io/circlize/.
 
 ## Examples
 
 See https://jokergoo.github.io/circlize_examples/.
 
-<img width="700" alt="circlize_example" src="http://jokergoo.github.io/circlize_book/book/images/ciclize_examples.jpg">
+<img width="700" alt="circlize_example" src="https://jokergoo.github.io/circlize_book/book/images/ciclize_examples.jpg">
 
 ## Install
 
@@ -48,11 +48,11 @@ devtools::install_github("jokergoo/circlize")
 
 ## Basic design
 
-Since most of the figures are composed of points, lines and polygons, 
+Since most of the figures are composed of points, lines and polygons,
 we just need to implement functions for drawing points, lines and polygons,
 then the plots will not be restricted in any specific types.
 
-Current there are following low-level graphic functions: 
+Current there are following low-level graphic functions:
 
 - `circos.points()`
 - `circos.lines()`
@@ -63,8 +63,8 @@ Current there are following low-level graphic functions:
 - `circos.raster()`
 - `circos.arrow()`
 - `circos.link()`, This maybe the unique feature for circos layout to represent relationships between elements.
- 
-For drawing points, lines and text through the whole track (among several sectors), the following 
+
+For drawing points, lines and text through the whole track (among several sectors), the following
 functions are available:
 
 - `circos.trackPoints()`
@@ -85,7 +85,7 @@ Theoretically, you are able to draw most kinds of circular plots by the above fu
 For specific use in Genomics, we also implement functions which add graphics in genome scale.
 
 Functions to initialize circular plot with genomic coordinates:
- 
+
 - `circos.initializeWithIdeogram()`
 - `circos.genomicInitialize()`
 

--- a/demo/foo.R
+++ b/demo/foo.R
@@ -1,11 +1,11 @@
 i = 1
 while(1) {
 	cat("\r")
-	str = paste(paste(rep(" ", i), collapse = ""), "http://jokergoo.github.io/circlize", collapse = "")
+	str = paste(paste(rep(" ", i), collapse = ""), "https://jokergoo.github.io/circlize", collapse = "")
 	i = i+1
 	if(nchar(str) > 80) {
 		cat(paste(rep(" ", 80), collapse = ""))
-		str = "http://jokergoo.github.io/circlize"
+		str = "https://jokergoo.github.io/circlize"
 		i = 0
 		cat("\r")
 	}

--- a/inst/extdata/download_and_slice_doodle.R
+++ b/inst/extdata/download_and_slice_doodle.R
@@ -6,7 +6,7 @@ tmp_file = tempfile(fileext = ".jpg")
 
 curl = getCurlHandle()
 bfile=getBinaryURL (
-    "http://www.thegreenhead.com/imgs/keith-haring-double-retrospect-worlds-largest-jigsaw-puzzle-2.jpg",
+    "https://www.thegreenhead.com/imgs/keith-haring-double-retrospect-worlds-largest-jigsaw-puzzle-2.jpg",
     curl= curl
 )
 writeBin(bfile, tmp_file)

--- a/inst/extdata/download_ucsc.R
+++ b/inst/extdata/download_ucsc.R
@@ -1,12 +1,12 @@
-species = scan(textConnection("anoGam1 apiMel2 braFlo1 caeJap1 caePb1 caePb2 caeRem2 caeRem3 
-canFam1 canFam2 cb1 cb3 cbJul2002 ce1 ce10 ce11 ce2 ce4 ce6 ceMay2003 danRer1 danRer2 danRer3 
-danRer4 dm1 dm2 dm3 dp2 dp3 droSim1 droYak1 droYak2 eboVir3 equCab1 equCab2 fr1 fr2 galGal2 
-galGal3 gasAcu1 hg10 hg11 hg12 hg13 hg15 hg16 hg17 hg18 hg19 hg38 hg6 hg7 hg8 mm1 mm10 mm2 
-mm3 mm4 mm5 mm6 mm7 mm8 mm9 monDom4 monDom5 panTro1 panTro2 ponAbe2 priPac1 rheMac2 rn1 rn2 
+species = scan(textConnection("anoGam1 apiMel2 braFlo1 caeJap1 caePb1 caePb2 caeRem2 caeRem3
+canFam1 canFam2 cb1 cb3 cbJul2002 ce1 ce10 ce11 ce2 ce4 ce6 ceMay2003 danRer1 danRer2 danRer3
+danRer4 dm1 dm2 dm3 dp2 dp3 droSim1 droYak1 droYak2 eboVir3 equCab1 equCab2 fr1 fr2 galGal2
+galGal3 gasAcu1 hg10 hg11 hg12 hg13 hg15 hg16 hg17 hg18 hg19 hg38 hg6 hg7 hg8 mm1 mm10 mm2
+mm3 mm4 mm5 mm6 mm7 mm8 mm9 monDom4 monDom5 panTro1 panTro2 ponAbe2 priPac1 rheMac2 rn1 rn2
 rn3 rn4 rn6 rnJan2003 rnJun2003 sacCer1 sacCer2 sacCer3 sc1 scApr2003 susScr2 taeGut1 tetNig1 tetNig2"), what = "character")
 
 cytoband_list = lapply(species, function(s) {
-	url = paste("http://hgdownload.cse.ucsc.edu/goldenPath/", s, "/database/cytoBand.txt.gz", sep = "")
+	url = paste("https://hgdownload.cse.ucsc.edu/goldenPath/", s, "/database/cytoBand.txt.gz", sep = "")
 	oe = try({
 		download.file(url, destfile = paste0(s, ".cytoBand.txt.gz"), quiet = TRUE)
 		d <- read.table(paste0(s, ".cytoBand.txt.gz"), colClasses = c("character", "numeric", "numeric", "character", "character"), sep = "\t", stringsAsFactors = FALSE)
@@ -27,7 +27,7 @@ saveRDS(cytoband_list, file = "~/project/circlize/inst/extdata/cytoband_list.rds
 
 
 chrom_info_list = lapply(species, function(s) {
-	url = paste("http://hgdownload.cse.ucsc.edu/goldenPath/", s, "/database/chromInfo.txt.gz", sep = "")
+	url = paste("https://hgdownload.cse.ucsc.edu/goldenPath/", s, "/database/chromInfo.txt.gz", sep = "")
 	oe = try({
 		download.file(url, destfile = paste0(s, ".chromInfo.txt.gz"), quiet = TRUE)
 		d <- read.table(paste0(s, ".chromInfo.txt.gz"), colClasses = c("character", "numeric"), sep = "\t", stringsAsFactors = FALSE)[1:2]

--- a/vignettes/circlize.Rmd
+++ b/vignettes/circlize.Rmd
@@ -3,4 +3,4 @@
 %\VignetteIndexEntry{circlize vignette}
 -->
 
-Please go to http://jokergoo.github.io/circlize_book/book/ for full vignette.
+Please go to https://jokergoo.github.io/circlize_book/book/ for full vignette.


### PR DESCRIPTION
Hi Zuguang,

I was reading some documentation & noticed that `http` and `https` were both used for links. This pull request is to switch as many links as possible to `https`.

Some external links have SSL cert configuation issues so I left them alone rather than generate a browser warning.

The .Rd and .html files are generated by the build process so the next time you run the build process, the `doc/` folder should be updated.

The next time you release to CRAN, those links should get updated as well.

Basically some minor housekeeping,