### PR TITLE
add `inverse` option to `circos.genomicLink`

### DIFF
--- a/R/genomic.R
+++ b/R/genomic.R
@@ -1490,6 +1490,7 @@ circos.genomicText = function(
 # -lwd Pass to `circos.link`, length can be either one or nrow of ``region1``.
 # -lty Pass to `circos.link`, length can be either one or nrow of ``region1``.
 # -border Pass to `circos.link`, length can be either one or nrow of ``region1``.
+# -inverse Pass to `circos.link`.
 # -... Pass to `circos.link`.
 #
 # == details
@@ -1524,6 +1525,7 @@ circos.genomicLink = function(
     lwd = par("lwd"), 
     lty = par("lty"), 
     border = col, 
+    inverse = NULL,
     ...) {
 
 	if(circos.par$ring) {
@@ -1570,6 +1572,14 @@ circos.genomicLink = function(
 	lwd = .normalizeGraphicalParam(lwd, 1, nr, "lwd")
 	lty = .normalizeGraphicalParam(lty, 1, nr, "lty")
 	border = .normalizeGraphicalParam(border, 1, nr, "border")
+	if(!is.null(inverse)) {
+		if(!is.logical(inverse) || any(is.na(inverse))) {
+			stop_wrap("`inverse` vector needs ot be boolean. Please check `inverse` vector type.")
+		}
+		if(length(inverse) != nr) {
+			stop_wrap("length of `inverse` vector and `region1` differ. Please check the length of the `inverse` vector.")
+		}
+	}
 
 	for(i in seq_len(nr)) {
 		if(region1[i, 2] == region1[i, 3]) {
@@ -1582,10 +1592,17 @@ circos.genomicLink = function(
 		} else {
 			point2 = c(region2[i, 2], region2[i, 3])
 		}
-		circos.link(region1[i, 1], point1,
+		if(!is.null(inverse)) {
+			circos.link(region1[i, 1], point1,
+		            region2[i, 1], point2,
+					rou1 = rou1[i], rou2 = rou2[i], col = col[i], lwd = lwd[i],
+					lty = lty[i], border = border[i], inverse = inverse[i], ...)
+		} else {
+			circos.link(region1[i, 1], point1,
 		            region2[i, 1], point2,
 					rou1 = rou1[i], rou2 = rou2[i], col = col[i], lwd = lwd[i],
 					lty = lty[i], border = border[i], ...)
+		}
 	}
 }
 

--- a/man/circos.genomicLink.Rd
+++ b/man/circos.genomicLink.Rd
@@ -17,20 +17,33 @@ circos.genomicLink(
     lwd = par("lwd"),
     lty = par("lty"),
     border = col,
+    inverse = NULL,
     ...)
 }
 \arguments{
 
-  \item{region1}{A data frame in bed format.}
-  \item{region2}{A data frame in bed format.}
-  \item{rou}{Pass to \code{\link{circos.link}}.}
-  \item{rou1}{Pass to \code{\link{circos.link}}.}
-  \item{rou2}{Pass to \code{\link{circos.link}}.}
-  \item{col}{Pass to \code{\link{circos.link}}, length can be either one or nrow of \code{region1}.}
-  \item{lwd}{Pass to \code{\link{circos.link}}, length can be either one or nrow of \code{region1}.}
-  \item{lty}{Pass to \code{\link{circos.link}}, length can be either one or nrow of \code{region1}.}
-  \item{border}{Pass to \code{\link{circos.link}}, length can be either one or nrow of \code{region1}.}
-  \item{...}{Pass to \code{\link{circos.link}}.}
+  \item{region1}{A data frame in bed format.
+}
+  \item{region2}{A data frame in bed format.
+}
+  \item{rou}{Pass to \code{\link{circos.link}}.
+}
+  \item{rou1}{Pass to \code{\link{circos.link}}.
+}
+  \item{rou2}{Pass to \code{\link{circos.link}}.
+}
+  \item{col}{Pass to \code{\link{circos.link}}, length can be either one or nrow of \code{region1}.
+}
+  \item{lwd}{Pass to \code{\link{circos.link}}, length can be either one or nrow of \code{region1}.
+}
+  \item{lty}{Pass to \code{\link{circos.link}}, length can be either one or nrow of \code{region1}.
+}
+  \item{border}{Pass to \code{\link{circos.link}}, length can be either one or nrow of \code{region1}.
+}
+  \item{inverse}{Pass to \code{\link{circos.link}}, length must be nrow of \code{region1}.
+}
+  \item{...}{Pass to \code{\link{circos.link}}.
+}
 
 }
 \details{


### PR DESCRIPTION
Dear @jokergoo,
I am using your great tool `circlize` to directly plot a circos plot from `mashmap` output:
see here:
https://github.com/kullrich/bio-scripts/blob/master/fasta/mashmap2circos.r
Anyhow, I realised that I could not directly use the `inverse` option from the `circos.link` function with the `circos.genomicLink` function. So I have added the `inverse` option to the `circos.genomicLink`.
With this it is now possible to do e.g.:

```
set.seed(123)

bed1 = generateRandomBed(nr = 100)
bed1 = bed1[sample(nrow(bed1), 20), ]
bed2 = generateRandomBed(nr = 100)
bed2 = bed2[sample(nrow(bed2), 20), ]
bed1[["strand"]] = c(rep("+",10),rep("-",10))
circos.par("track.height" = 0.1, cell.padding = c(0, 0, 0, 0))
circos.initializeWithIdeogram()

circos.genomicLink(bed1, bed2, col = sample(1:5, 20, replace = TRUE), border = NA, inverse = bed1[["strand"]] == "-")
circos.clear()
```

I hope that you find this option useful to be added to your R package.

Best regards

Kristian